### PR TITLE
Fix prefix property for Quick Creation pads

### DIFF
--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -749,6 +749,7 @@ class ComponentPlacer(QObject):
                 testability=pad.get("testability", "Forced"),
                 technology=pad["technology"],
                 angle_deg=pad["angle_deg"],
+                prefix=pad.get("prefix"),
             )
             new_objs.append(obj)
 


### PR DESCRIPTION
## Summary
- ensure quick created pads keep the prefix value when placing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fcdddc4d8832cb9c60a986e9ca15e