### PR TITLE
Add numeric Quick Creation prefixes

### DIFF
--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -973,10 +973,12 @@ class ComponentPlacer(QObject):
             if create_prefix and scheme in (1, 2):
                 if scheme == 1:
                     prefix_idx = row_vis.index(r)
+                    number_idx = col_vis.index(c) + 1
                 else:
                     prefix_idx = col_vis.index(c)
+                    number_idx = row_vis.index(r) + 1
                 letter = prefix_table[prefix_idx % len(prefix_table)]
-                pad["prefix"] = letter
+                pad["prefix"] = f"{letter}{number_idx}"
             ordered.append(pad)
 
         fp["pads"] = ordered


### PR DESCRIPTION
## Summary
- assign row/column index numbers to Quick Creation prefix letters

## Testing
- `ruff check component_placer/component_placer.py`
- `black component_placer/component_placer.py --check`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_684fd1075b70832ca6f9ca637ece59d2