### PR TITLE
Enhance backup flow and start dialog

### DIFF
--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -126,10 +126,17 @@ class MainWindow(QMainWindow):
 
         # ─── Startup dialog to open or create a project ──────────────────
         start_dlg = StartDialog(self)
-        start_dlg.open_button.clicked.connect(self.project_manager.open_project_dialog)
-        start_dlg.create_button.clicked.connect(
-            self.project_manager.create_project_dialog
-        )
+
+        def _open():
+            start_dlg.accept()
+            self.project_manager.open_project_dialog()
+
+        def _create():
+            start_dlg.accept()
+            self.project_manager.create_project_dialog()
+
+        start_dlg.open_button.clicked.connect(_open)
+        start_dlg.create_button.clicked.connect(_create)
         start_dlg.exec_()
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- close the startup dialog once an option is chosen
- ensure backup folder is available when opening or creating a project
- allow selecting backup folder if none is found when restoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505657271c832c861a5765d32bf777