### PR TITLE
Add board origin dialog

### DIFF
--- a/ui/board_origin_dialog.py
+++ b/ui/board_origin_dialog.py
@@ -1,0 +1,68 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QFormLayout,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QLabel,
+)
+from PyQt5.QtGui import QDoubleValidator
+
+
+class BoardOriginDialog(QDialog):
+    """Dialog to edit board origin coordinates for top and bottom images."""
+
+    def __init__(self, constants, parent=None):
+        super().__init__(parent)
+        self.constants = constants
+        self.setWindowTitle("Set Board Origin")
+        self._init_ui()
+
+    def _init_ui(self):
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.top_x_edit = QLineEdit()
+        validator = QDoubleValidator(-1e6, 1e6, 8, self.top_x_edit)
+        self.top_x_edit.setValidator(validator)
+        self.top_x_edit.setText(str(self.constants.get("TopImageXCoord", 0.0)))
+        form.addRow(QLabel("TopImageXCoord"), self.top_x_edit)
+
+        self.top_y_edit = QLineEdit()
+        validator = QDoubleValidator(-1e6, 1e6, 8, self.top_y_edit)
+        self.top_y_edit.setValidator(validator)
+        self.top_y_edit.setText(str(self.constants.get("TopImageYCoord", 0.0)))
+        form.addRow(QLabel("TopImageYCoord"), self.top_y_edit)
+
+        self.bottom_x_edit = QLineEdit()
+        validator = QDoubleValidator(-1e6, 1e6, 8, self.bottom_x_edit)
+        self.bottom_x_edit.setValidator(validator)
+        self.bottom_x_edit.setText(str(self.constants.get("BottomImageXCoord", 0.0)))
+        form.addRow(QLabel("BottomImageXCoord"), self.bottom_x_edit)
+
+        self.bottom_y_edit = QLineEdit()
+        validator = QDoubleValidator(-1e6, 1e6, 8, self.bottom_y_edit)
+        self.bottom_y_edit.setValidator(validator)
+        self.bottom_y_edit.setText(str(self.constants.get("BottomImageYCoord", 0.0)))
+        form.addRow(QLabel("BottomImageYCoord"), self.bottom_y_edit)
+
+        layout.addLayout(form)
+
+        buttons = QHBoxLayout()
+        ok_btn = QPushButton("OK")
+        cancel_btn = QPushButton("Cancel")
+        ok_btn.clicked.connect(self.accept)
+        cancel_btn.clicked.connect(self.reject)
+        buttons.addStretch()
+        buttons.addWidget(ok_btn)
+        buttons.addWidget(cancel_btn)
+        layout.addLayout(buttons)
+
+    def get_values(self):
+        return {
+            "TopImageXCoord": float(self.top_x_edit.text() or 0.0),
+            "TopImageYCoord": float(self.top_y_edit.text() or 0.0),
+            "BottomImageXCoord": float(self.bottom_x_edit.text() or 0.0),
+            "BottomImageYCoord": float(self.bottom_y_edit.text() or 0.0),
+        }

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -478,27 +478,16 @@ class MainWindow(QMainWindow):
         tx_old = self.constants.get("TopImageXCoord", 0.0)
         ty_old = self.constants.get("TopImageYCoord", 0.0)
 
-        # -- get two doubles -------------------------------------------------
-        tx, ok1 = QInputDialog.getDouble(
-            self, "Board Origin", "Top Image X (mm):", tx_old, -1e6, 1e6, 3
-        )
-        if not ok1:
+        from ui.board_origin_dialog import BoardOriginDialog
+
+        dlg = BoardOriginDialog(self.constants, parent=self)
+        if dlg.exec_() != dlg.Accepted:
             return
-        ty, ok2 = QInputDialog.getDouble(
-            self, "Board Origin", "Top Image Y (mm):", ty_old, -1e6, 1e6, 3
-        )
-        if not ok2:
-            return
-        bx, ok3 = QInputDialog.getDouble(
-            self, "Board Origin", "Bottom Image X (mm):", bx_old, -1e6, 1e6, 3
-        )
-        if not ok3:
-            return
-        by, ok4 = QInputDialog.getDouble(
-            self, "Board Origin", "Bottom Image Y (mm):", by_old, -1e6, 1e6, 3
-        )
-        if not ok4:
-            return
+        values = dlg.get_values()
+        tx = values["TopImageXCoord"]
+        ty = values["TopImageYCoord"]
+        bx = values["BottomImageXCoord"]
+        by = values["BottomImageYCoord"]
 
         dx = tx - tx_old
         dy = ty - ty_old


### PR DESCRIPTION
## Summary
- open board origin parameters in a single dialog
- update `set_board_origin` to use the dialog

## Testing
- `pytest -q`
- `pre-commit run --files ui/board_origin_dialog.py ui/main_menu.py` *(fails: CalledProcessError during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_6851108aad24832cbe81eb74b9509ed0