### PR TITLE
Refine logging noise

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -2,23 +2,30 @@
 
 import json
 import os
+from logs.log_handler import LogHandler
+
 
 class Constants:
     def __init__(self, file_path=None):
         if file_path is None:
             current_dir = os.path.dirname(os.path.abspath(__file__))
             file_path = os.path.join(current_dir, "constants.txt")
-        
+
         self.file_path = file_path
         self.data = {}
+        self.log = LogHandler()
         try:
             with open(self.file_path, "r") as file:
                 self.data = json.load(file)
         except FileNotFoundError:
-            print(f"Warning: Constants file not found at '{self.file_path}'. Using default values.")
+            self.log.warning(
+                f"Constants file not found at '{self.file_path}'. Using default values."
+            )
         except json.JSONDecodeError:
-            print(f"Error: Malformed constants file at '{self.file_path}'. Using default values.")
-    
+            self.log.error(
+                f"Malformed constants file at '{self.file_path}'. Using default values."
+            )
+
     def get(self, key, default=None):
         return self.data.get(key, default)
 
@@ -30,7 +37,7 @@ class Constants:
         :param value: The value to assign to the key.
         """
         self.data[key] = value
-        print(f"Constants updated: {key} = {value}")
+        self.log.debug(f"Constants updated: {key} = {value}")
 
     def save(self):
         """
@@ -39,6 +46,6 @@ class Constants:
         try:
             with open(self.file_path, "w") as file:
                 json.dump(self.data, file, indent=4)
-            print(f"Constants saved to '{self.file_path}'.")
+            self.log.info(f"Constants saved to '{self.file_path}'.")
         except Exception as e:
-            print(f"Error saving constants: {e}")
+            self.log.error(f"Error saving constants: {e}")

--- a/constants/constants.txt
+++ b/constants/constants.txt
@@ -2,6 +2,7 @@
     "log_file": "logs/program.txt",
     "log_max_size": 5000000,
     "log_backup_count": 5,
+    "debug_mode": false,
     "current_project_path": null,
     "project_loaded": false,
     "zoom_center_mode": "marker",

--- a/ui/board_view/board_view.py
+++ b/ui/board_view/board_view.py
@@ -466,7 +466,7 @@ class BoardView(QGraphicsView):
     def center_on(self, x: float, y: float):
         point = QPointF(x, y)
         self.centerOn(point)
-        self.log.log("info", f"View centered on ({x:.2f}, {y:.2f}).")
+        self.log.log("debug", f"View centered on ({x:.2f}, {y:.2f}).")
 
     def show_context_menu(self, selected_pads, global_pos):
         """
@@ -830,7 +830,7 @@ class BoardView(QGraphicsView):
         self.board_contour_item = QGraphicsRectItem(board_rect)
         self.board_contour_item.setPen(contour_pen)
         self.scene.addItem(self.board_contour_item)
-        self.log.log("info", f"Board contour added: {board_rect}")
+        self.log.log("debug", f"Board contour added: {board_rect}")
 
     def update_scene(self):
         """

--- a/ui/layers_tab.py
+++ b/ui/layers_tab.py
@@ -1,16 +1,22 @@
 # ui/layers_tab.py
 
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QGroupBox, QHBoxLayout, QFormLayout,
-    QLineEdit, QComboBox, QPushButton, QCheckBox, QMessageBox
+    QWidget,
+    QVBoxLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QFormLayout,
+    QLineEdit,
+    QComboBox,
+    QPushButton,
+    QCheckBox,
 )
 from PyQt5.QtCore import Qt
-from display.pad_shapes import build_pad_path  # if needed for conversion
-from constants.constants import Constants
-from logs.log_handler import LogHandler
+
 
 # Conversion factor for mm to mils (if you want to allow unit conversion later)
 MM_TO_MILS = 39.37
+
 
 class LayersTab(QWidget):
     """
@@ -18,6 +24,7 @@ class LayersTab(QWidget):
       - Toggle the PCB image (JPG) layer and the pads layer.
       - Filter the pads by various criteria. Only pads matching the filter remain visible.
     """
+
     def __init__(self, board_view, parent=None):
         """
         :param board_view: An instance of BoardView; used to access the image and DisplayLibrary.
@@ -69,7 +76,16 @@ class LayersTab(QWidget):
         self.tech_filter.addItems(["", "SMD", "Through Hole", "Mechanical"])
 
         self.shape_filter = QComboBox()
-        self.shape_filter.addItems(["", "Round", "Square/rectangle", "Square/rectangle with Hole", "Ellipse", "Hole"])
+        self.shape_filter.addItems(
+            [
+                "",
+                "Round",
+                "Square/rectangle",
+                "Square/rectangle with Hole",
+                "Ellipse",
+                "Hole",
+            ]
+        )
 
         self.width_filter = QLineEdit()
         self.height_filter = QLineEdit()
@@ -108,58 +124,79 @@ class LayersTab(QWidget):
         - If unchecked (visible=False), hide both top and bottom images and add a contour.
         This function does not switch sides.
         """
-        visible = (state == Qt.Checked)
+        visible = state == Qt.Checked
         # Update the flag on the board view.
         self.board_view.image_hidden_by_filter = not visible
 
         # Log the intended state along with the current side.
         current_side = self.board_view.flags.get_flag("side", "top")
-        self.log.log("debug", f"toggle_image_visibility: state={state} (visible={visible}), current_side={current_side}")
+        self.log.log(
+            "debug",
+            f"toggle_image_visibility: state={state} (visible={visible}), current_side={current_side}",
+        )
 
         if visible:
             # Ensure that only the current side's image is visible.
             if current_side == "top":
                 if self.board_view.top_pixmap_item:
-                    self.log.log("debug", "toggle_image_visibility: Showing top_pixmap_item.")
+                    self.log.log(
+                        "debug", "toggle_image_visibility: Showing top_pixmap_item."
+                    )
                     self.board_view.top_pixmap_item.setVisible(True)
                 if self.board_view.bottom_pixmap_item:
-                    self.log.log("debug", "toggle_image_visibility: Hiding bottom_pixmap_item.")
+                    self.log.log(
+                        "debug", "toggle_image_visibility: Hiding bottom_pixmap_item."
+                    )
                     self.board_view.bottom_pixmap_item.setVisible(False)
             else:  # current_side == "bottom"
                 if self.board_view.bottom_pixmap_item:
-                    self.log.log("debug", "toggle_image_visibility: Showing bottom_pixmap_item.")
+                    self.log.log(
+                        "debug", "toggle_image_visibility: Showing bottom_pixmap_item."
+                    )
                     self.board_view.bottom_pixmap_item.setVisible(True)
                 if self.board_view.top_pixmap_item:
-                    self.log.log("debug", "toggle_image_visibility: Hiding top_pixmap_item.")
+                    self.log.log(
+                        "debug", "toggle_image_visibility: Hiding top_pixmap_item."
+                    )
                     self.board_view.top_pixmap_item.setVisible(False)
             # Remove any existing board contour.
-            if hasattr(self.board_view, "board_contour_item") and self.board_view.board_contour_item:
-                self.log.log("debug", "toggle_image_visibility: Removing existing board contour.")
+            if (
+                hasattr(self.board_view, "board_contour_item")
+                and self.board_view.board_contour_item
+            ):
+                self.log.log(
+                    "debug", "toggle_image_visibility: Removing existing board contour."
+                )
                 self.board_view.scene.removeItem(self.board_view.board_contour_item)
                 self.board_view.board_contour_item = None
-            self.log.log("info", "PCB Image set to visible.")
+            self.log.log("debug", "PCB Image set to visible.")
         else:
             # Force both images to be hidden.
             if self.board_view.top_pixmap_item:
-                self.log.log("debug", "toggle_image_visibility: Hiding top_pixmap_item.")
+                self.log.log(
+                    "debug", "toggle_image_visibility: Hiding top_pixmap_item."
+                )
                 self.board_view.top_pixmap_item.setVisible(False)
             if self.board_view.bottom_pixmap_item:
-                self.log.log("debug", "toggle_image_visibility: Hiding bottom_pixmap_item.")
+                self.log.log(
+                    "debug", "toggle_image_visibility: Hiding bottom_pixmap_item."
+                )
                 self.board_view.bottom_pixmap_item.setVisible(False)
             # Add a board contour if not already present.
-            if not hasattr(self.board_view, "board_contour_item") or self.board_view.board_contour_item is None:
+            if (
+                not hasattr(self.board_view, "board_contour_item")
+                or self.board_view.board_contour_item is None
+            ):
                 self.log.log("debug", "toggle_image_visibility: Adding board contour.")
                 self.board_view.add_board_contour()
             else:
-                self.log.log("debug", "toggle_image_visibility: Board contour already exists.")
-            self.log.log("info", "PCB Image set to hidden; board contour displayed.")
-
-
-
-
+                self.log.log(
+                    "debug", "toggle_image_visibility: Board contour already exists."
+                )
+            self.log.log("debug", "PCB Image set to hidden; board contour displayed.")
 
     def toggle_pads_visibility(self, state):
-        visible = (state == Qt.Checked)
+        visible = state == Qt.Checked
         # Iterate over all pad items stored in DisplayLibrary.
         for item in self.display_library.displayed_objects.values():
             # Check that the item is a pad item (it is created as a SelectablePadItem).
@@ -168,7 +205,7 @@ class LayersTab(QWidget):
                 item.setVisible(visible)
             except Exception as e:
                 self.log.log("error", f"Error toggling pad visibility: {e}")
-        self.log.log("info", f"Pads visibility set to {visible}.")
+        self.log.log("debug", f"Pads visibility set to {visible}.")
 
     # ----- Pad Filter Methods -----
 
@@ -239,14 +276,14 @@ class LayersTab(QWidget):
             else:
                 pad_obj.visible = False
 
-        self.log.log("info", f"Filter applied: {count_matched} out of {count_total} pads are visible.")
+        self.log.log(
+            "debug",
+            f"Filter applied: {count_matched} out of {count_total} pads are visible.",
+        )
 
         # Clear and re-render the display so that only pads with visible == True are drawn.
         self.board_view.display_library.clear_all_rendered_objects()
         self.board_view.display_library.render_initial_objects()
-
-
-
 
     def reset_filter(self):
         """
@@ -269,12 +306,11 @@ class LayersTab(QWidget):
         for pad_obj in self.board_view.object_library.get_all_objects():
             pad_obj.visible = True
 
-        self.log.log("info", "Filter reset: all pads are now visible.")
+        self.log.log("debug", "Filter reset: all pads are now visible.")
 
         # Clear and re-render the display so that all pads are drawn.
         self.board_view.display_library.clear_all_rendered_objects()
         self.board_view.display_library.render_initial_objects()
-
 
     def reapply_filter(self):
         """
@@ -283,9 +319,16 @@ class LayersTab(QWidget):
         and the pad items have been re-rendered.
         """
         # Check if any filter field is set (you might check a few key fields).
-        if (self.pin_filter.text().strip() or self.channel_filter.text().strip() or
-            self.signal_filter.text().strip() or self.component_filter.text().strip() or
-            self.testpos_filter.currentText().strip() or self.tech_filter.currentText().strip() or
-            self.shape_filter.currentText().strip() or self.width_filter.text().strip() or
-            self.height_filter.text().strip() or self.hole_filter.text().strip()):
+        if (
+            self.pin_filter.text().strip()
+            or self.channel_filter.text().strip()
+            or self.signal_filter.text().strip()
+            or self.component_filter.text().strip()
+            or self.testpos_filter.currentText().strip()
+            or self.tech_filter.currentText().strip()
+            or self.shape_filter.currentText().strip()
+            or self.width_filter.text().strip()
+            or self.height_filter.text().strip()
+            or self.hole_filter.text().strip()
+        ):
             self.apply_filter()  # Reapply the filter if any field is not empty.

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -289,13 +289,13 @@ class MainWindow(QMainWindow):
     def update_project_name(self, folder_name: str):
         if folder_name:
             self.project_name_label.setText(f"Project: {folder_name}")
-            self.log.log("info", f"Project name label set to: '{folder_name}'")
+            self.log.log("debug", f"Project name label set to: '{folder_name}'")
             # enable Restore‑Backup once a project is open
             if hasattr(self, "restore_backup_action"):
                 self.restore_backup_action.setEnabled(True)
         else:
             self.project_name_label.setText("Project: [None]")
-            self.log.log("info", "Project name label set to: '[None]'")
+            self.log.log("debug", "Project name label set to: '[None]'")
             if hasattr(self, "restore_backup_action"):
                 self.restore_backup_action.setEnabled(False)
 
@@ -338,7 +338,7 @@ class MainWindow(QMainWindow):
             self.board_view.marker_manager.place_marker_from_scene
         )
         self.input_handler.wheel_moved.connect(self.board_view.wheelEvent)
-        self.log.log("info", "All wiring completed successfully.")
+        self.log.log("debug", "All wiring completed successfully.")
 
     # --------------------------------------------------------------------------
     #  Menus: "File" (Open, Save, SaveAs, Create Project), "Project" (Load Top, etc.)
@@ -473,10 +473,6 @@ class MainWindow(QMainWindow):
         • May optionally shift every pad by ΔX, ΔY
         • Re-positions the marker so it stays visually correct.
         """
-        bx_old = self.constants.get("BottomImageXCoord", 0.0)
-        by_old = self.constants.get("BottomImageYCoord", 0.0)
-        tx_old = self.constants.get("TopImageXCoord", 0.0)
-        ty_old = self.constants.get("TopImageYCoord", 0.0)
 
         from ui.board_origin_dialog import BoardOriginDialog
 
@@ -489,8 +485,10 @@ class MainWindow(QMainWindow):
         bx = values["BottomImageXCoord"]
         by = values["BottomImageYCoord"]
 
-        dx = tx - tx_old
-        dy = ty - ty_old
+        old_tx = self.constants.get("TopImageXCoord", 0.0)
+        old_ty = self.constants.get("TopImageYCoord", 0.0)
+        dx = tx - old_tx
+        dy = ty - old_ty
 
         # -- current marker position *before* anything changes ---------------
         old_marker_mm = self.board_view.marker_manager.get_marker_board_coords()
@@ -648,7 +646,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "Info", f"'{path}' is not a .nod file.")
             return
 
-        self.log.log("info", f"Double-clicked .nod file: {path}")
+        self.log.log("debug", f"Double-clicked .nod file: {path}")
         footprint = get_footprint_for_placer(path)
         if footprint and "pads" in footprint:
             self.component_placer.footprint = footprint
@@ -695,7 +693,7 @@ class MainWindow(QMainWindow):
         mode = "mouse" if index == 0 else "marker"
         self.constants.set("zoom_center_mode", mode)
         self.constants.save()
-        self.log.log("info", f"Zoom center mode changed to {mode}.")
+        self.log.log("debug", f"Zoom center mode changed to {mode}.")
 
     def update_zoom_level_label(self):
         if not self.board_view or not self.board_view.zoom_manager:
@@ -717,14 +715,14 @@ class MainWindow(QMainWindow):
         )
 
     def on_switch_side(self):
-        self.log.log("info", "Switch Side button clicked.")
+        self.log.log("debug", "Switch Side button clicked.")
         self.board_view.switch_side()
         # After switching, update the working side label.
         current_side = self.board_view.flags.get_flag("side", "top").capitalize()
         self.working_side_label.setText(f"Working Side: {current_side}")
 
     def open_search_dialog(self):
-        self.log.log("info", "Opening Search Dialog.")
+        self.log.log("debug", "Opening Search Dialog.")
         # Pass the QTextBrowser widget from the PropertiesDock that displays selected pins info.
         search_dialog = SearchDialog(
             board_view=self.board_view,
@@ -732,9 +730,9 @@ class MainWindow(QMainWindow):
             parent=self,
         )
         if search_dialog.exec_() == QDialog.Accepted:
-            self.log.log("info", "Search Dialog completed successfully.")
+            self.log.log("debug", "Search Dialog completed successfully.")
         else:
-            self.log.log("info", "Search Dialog was canceled.")
+            self.log.log("debug", "Search Dialog was canceled.")
 
     def create_font_controls(self):
         """
@@ -1101,7 +1099,7 @@ class MainWindow(QMainWindow):
         if ok:
             self.constants.set("anchor_nudge_step_mm", value)
             self.constants.save()
-            self.log.log("info", f"Anchor nudge step updated to {value} mm")
+            self.log.log("debug", f"Anchor nudge step updated to {value} mm")
 
     def set_max_zoom(self):
         """Prompt user to set maximum zoom level."""
@@ -1121,7 +1119,7 @@ class MainWindow(QMainWindow):
             if hasattr(self.board_view, "zoom_manager"):
                 self.board_view.zoom_manager.max_user_scale = value
                 self.board_view.zoom_manager.update_zoom_limits()
-            self.log.log("info", f"Max zoom updated to {value}")
+            self.log.log("debug", f"Max zoom updated to {value}")
 
     def set_quick_prefix_table(self):
         """Prompt user to edit the comma-separated quick prefix table."""

--- a/ui/zoom_manager.py
+++ b/ui/zoom_manager.py
@@ -6,9 +6,10 @@ from PyQt5.QtWidgets import QGraphicsView
 from logs.log_handler import LogHandler
 from constants.constants import Constants
 
+
 class ZoomManager(QObject):
     """
-    A simpler ZoomManager that performs single-step ("jump") zooms 
+    A simpler ZoomManager that performs single-step ("jump") zooms
     around the chosen anchor. Doesn't reset the transform or call fitInView
     after each zoom, so the anchor remains stable.
     """
@@ -64,9 +65,13 @@ class ZoomManager(QObject):
 
         # Always recalc the current mouse scene position using QCursor.pos()
         mouse_global = QCursor.pos()
-        mouse_scene = self.board_view.mapToScene(self.board_view.mapFromGlobal(mouse_global))
-        self.log.log("info",
-                     f"Zoom mode: CURSOR. Current cursor scene position: ({mouse_scene.x():.2f}, {mouse_scene.y():.2f}).")
+        mouse_scene = self.board_view.mapToScene(
+            self.board_view.mapFromGlobal(mouse_global)
+        )
+        self.log.log(
+            "debug",
+            f"Zoom mode: CURSOR. Current cursor scene position: ({mouse_scene.x():.2f}, {mouse_scene.y():.2f}).",
+        )
 
         # Apply scaling.
         self.board_view.scale(actual_factor, actual_factor)
@@ -74,21 +79,29 @@ class ZoomManager(QObject):
         # Re-center the view according to zoom mode.
         if zoom_mode in ("cursor", "mouse"):
             self.board_view.centerOn(mouse_scene)
-            self.log.log("info",
-                         f"View recentered on cursor scene position: ({mouse_scene.x():.2f}, {mouse_scene.y():.2f}).")
+            self.log.log(
+                "debug",
+                f"View recentered on cursor scene position: ({mouse_scene.x():.2f}, {mouse_scene.y():.2f}).",
+            )
         elif zoom_mode == "marker":
             marker_coords = self.board_view.marker_manager.get_marker_board_coords()
             if marker_coords:
                 x_px, y_px = self.board_view.converter.mm_to_pixels(*marker_coords)
                 self.board_view.centerOn(x_px, y_px)
-                self.log.log("info",
-                             f"View recentered on marker at scene: ({x_px:.2f}, {y_px:.2f}).")
+                self.log.log(
+                    "debug",
+                    f"View recentered on marker at scene: ({x_px:.2f}, {y_px:.2f}).",
+                )
             else:
-                self.log.log("warning", "Zoom mode 'marker' active but no marker available.")
+                self.log.log(
+                    "warning", "Zoom mode 'marker' active but no marker available."
+                )
 
-        self.log.log("info",
-                     f"Zoom applied: old scale={old_scale:.3f}, new scale={self.user_scale:.3f}, "
-                     f"factor applied={actual_factor:.3f}, mode={zoom_mode}.")
+        self.log.log(
+            "debug",
+            f"Zoom applied: old scale={old_scale:.3f}, new scale={self.user_scale:.3f}, "
+            f"factor applied={actual_factor:.3f}, mode={zoom_mode}.",
+        )
         self.scale_factor_changed.emit(self.user_scale)
 
     def update_zoom_limits(self):


### PR DESCRIPTION
## Summary
- lower per-object messages to debug level
- avoid clutter when centering on the board or adding contours
- reduce zoom, layer, and menu logs to debug messages
- format sources and clean unused variables

## Testing
- `ruff check objects/object_library.py ui/board_view/board_view.py ui/zoom_manager.py ui/layers_tab.py ui/main_menu.py`
- `black objects/object_library.py ui/board_view/board_view.py ui/zoom_manager.py ui/layers_tab.py ui/main_menu.py --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852622aebd8832ca07cd3f396106c80