### PR TITLE
Add PCB digitation hole filter

### DIFF
--- a/constants/constants.txt
+++ b/constants/constants.txt
@@ -7,6 +7,7 @@
     "project_loaded": false,
     "zoom_center_mode": "marker",
     "z_value_image": 0,
+    "z_value_cutouts": 0.5,
     "z_value_pads": 1,
     "z_value_marker": 2,
     "z_value_ghost": 3,

--- a/ui/board_view/board_view.py
+++ b/ui/board_view/board_view.py
@@ -75,6 +75,7 @@ class BoardView(QGraphicsView):
         # Use the passed-in constants
         self.constants = constants if constants else Constants()
         self.z_value_image = self.constants.get("z_value_image", 0)
+        self.z_value_cutouts = self.constants.get("z_value_cutouts", 0.5)
 
         # Explicitly set side to "top" on init if desired (like old code did)
         self.flags.set_flag("side", "top")
@@ -92,8 +93,11 @@ class BoardView(QGraphicsView):
         # Groups for items
         self.display_group = QGraphicsItemGroup()
         self.marker_group = QGraphicsItemGroup()
+        self.cutout_group = QGraphicsItemGroup()
         self.scene.addItem(self.display_group)
         self.scene.addItem(self.marker_group)
+        self.scene.addItem(self.cutout_group)
+        self.cutout_items = []
 
         self.setCacheMode(QGraphicsView.CacheBackground)
         self.scene.selectionChanged.connect(self.on_scene_selection_changed)
@@ -891,3 +895,53 @@ class BoardView(QGraphicsView):
                 return
 
         super().mouseDoubleClickEvent(event)
+
+    # ------------------------------------------------------------------
+    #  Digitation Holes Handling
+    # ------------------------------------------------------------------
+    def calculate_component_rects(self):
+        """Return bounding rectangles for each component in mm."""
+        comp_rects = {}
+        for obj in self.object_library.get_all_objects():
+            comp = obj.component_name
+            half_w = obj.width_mm / 2.0
+            half_h = obj.height_mm / 2.0
+            x1 = obj.x_coord_mm - half_w
+            x2 = obj.x_coord_mm + half_w
+            y1 = obj.y_coord_mm - half_h
+            y2 = obj.y_coord_mm + half_h
+            if comp not in comp_rects:
+                comp_rects[comp] = [x1, y1, x2, y2]
+            else:
+                r = comp_rects[comp]
+                r[0] = min(r[0], x1)
+                r[1] = min(r[1], y1)
+                r[2] = max(r[2], x2)
+                r[3] = max(r[3], y2)
+        return comp_rects
+
+    def show_digitation_holes(self, enable: bool):
+        """Overlay rectangles to simulate holes where digitation was made."""
+        for item in list(self.cutout_items):
+            self.cutout_group.removeFromGroup(item)
+            self.scene.removeItem(item)
+        self.cutout_items.clear()
+
+        if not enable:
+            return
+
+        from PyQt5.QtCore import QRectF
+        from PyQt5.QtGui import QBrush, QPen
+
+        rects = self.calculate_component_rects()
+        for rect in rects.values():
+            x1, y1, x2, y2 = rect
+            x1_px, y1_px = self.converter.mm_to_pixels(x1, y1)
+            x2_px, y2_px = self.converter.mm_to_pixels(x2, y2)
+            qrect = QRectF(x1_px, y1_px, x2_px - x1_px, y2_px - y1_px)
+            item = QGraphicsRectItem(qrect)
+            item.setBrush(QBrush(Qt.white))
+            item.setPen(QPen(Qt.NoPen))
+            item.setZValue(self.z_value_cutouts)
+            self.cutout_group.addToGroup(item)
+            self.cutout_items.append(item)

--- a/ui/layers_tab.py
+++ b/ui/layers_tab.py
@@ -54,8 +54,14 @@ class LayersTab(QWidget):
         self.chk_show_pads.setChecked(True)
         self.chk_show_pads.stateChanged.connect(self.toggle_pads_visibility)
 
+        # Checkbox to cut digitation areas from the PCB image
+        self.chk_cut_dig = QCheckBox("Cut Digitation Area")
+        self.chk_cut_dig.setChecked(False)
+        self.chk_cut_dig.stateChanged.connect(self.toggle_cut_digitation)
+
         vis_layout.addWidget(self.chk_show_image)
         vis_layout.addWidget(self.chk_show_pads)
+        vis_layout.addWidget(self.chk_cut_dig)
         layout.addWidget(visibility_group)
 
         # ---- Pad Filter Group ----
@@ -206,6 +212,11 @@ class LayersTab(QWidget):
             except Exception as e:
                 self.log.log("error", f"Error toggling pad visibility: {e}")
         self.log.log("debug", f"Pads visibility set to {visible}.")
+
+    def toggle_cut_digitation(self, state):
+        enable = state == Qt.Checked
+        self.log.log("debug", f"Cut digitation toggled: {enable}")
+        self.board_view.show_digitation_holes(enable)
 
     # ----- Pad Filter Methods -----
 


### PR DESCRIPTION
## Summary
- add `Cut Digitation Area` checkbox to Layers tab
- implement toggle handler in LayersTab
- manage cutout overlays in BoardView and new constant `z_value_cutouts`
- fix pen type when drawing hole overlays

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m py_compile ui/layers_tab.py ui/board_view/board_view.py`


------
https://chatgpt.com/codex/tasks/task_e_6852b50f8f08832cb6ce71e4da7fddc2