### PR TITLE
Fix layer visibility when switching sides

### DIFF
--- a/ui/layers_tab.py
+++ b/ui/layers_tab.py
@@ -203,6 +203,7 @@ class LayersTab(QWidget):
 
     def toggle_pads_visibility(self, state):
         visible = state == Qt.Checked
+        self.board_view.pads_hidden_by_filter = not visible
         # Iterate over all pad items stored in DisplayLibrary.
         for item in self.display_library.displayed_objects.values():
             # Check that the item is a pad item (it is created as a SelectablePadItem).


### PR DESCRIPTION
## Summary
- track layer visibility states in `BoardView`
- restore pad visibility on side change
- refresh digitation holes when sides switch
- remember pad visibility from the Layers tab

## Testing
- `ruff check ui/board_view/board_view.py ui/layers_tab.py`
- `black ui/board_view/board_view.py ui/layers_tab.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852bacaaa60832c97386a1757bdbb59