### PR TITLE
Adjust digitation cutouts to honor board side

### DIFF
--- a/ui/board_view/board_view.py
+++ b/ui/board_view/board_view.py
@@ -923,9 +923,24 @@ class BoardView(QGraphicsView):
     #  Digitation Holes Handling
     # ------------------------------------------------------------------
     def calculate_component_rects(self):
-        """Return bounding rectangles for each component in mm."""
+        """Return bounding rectangles for visible components on the current side."""
         comp_rects = {}
+        current_side = self.display_library.current_side
         for obj in self.object_library.get_all_objects():
+            if not getattr(obj, "visible", True):
+                continue
+
+            tech = obj.technology.lower()
+            tp = obj.test_position.lower()
+            if tech == "through hole":
+                include = True
+            elif tech == "smd" and tp == current_side:
+                include = True
+            else:
+                include = False
+            if not include:
+                continue
+
             comp = obj.component_name
             half_w = obj.width_mm / 2.0
             half_h = obj.height_mm / 2.0


### PR DESCRIPTION
## Summary
- only generate digitation rectangles for objects visible on the current side

## Testing
- `pre-commit run --files ui/board_view/board_view.py` *(fails: pathspec 'v3.2.4' did not match any file)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bcb36588832c941c553f0f15afac