### PR TITLE
Implement quick creation improvements

### DIFF
--- a/component_placer/bom_handler/bom_editor_dialog.py
+++ b/component_placer/bom_handler/bom_editor_dialog.py
@@ -30,6 +30,8 @@ class BOMEditorDialog(QDialog):
         self.bom_handler = bom_handler
         self.board_set = board_component_names  # a set of board component names
         self.setWindowTitle("BOM Editor - Mismatch Fix")
+        # Make the dialog larger by default
+        self.resize(800, 600)
         
         # Compute mismatch sets (missing: on board not in BOM, extra: in BOM not on board)
         self.missing_set, self.extra_set = self._compute_mismatch()

--- a/component_placer/component_input_dialog.py
+++ b/component_placer/component_input_dialog.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import (
     QFormLayout,
     QHBoxLayout,
     QLineEdit,
+    QSpinBox,
     QComboBox,
     QCheckBox,
     QDialogButtonBox,
@@ -140,12 +141,13 @@ class ComponentInputDialog(QDialog):
         self.auto_numbering_checkbox.toggled.connect(self.update_component_name)
 
         # ── 2. QUICK-CREATION FIELDS ──────────────────────────────────────
-        self.x_pins_edit = QLineEdit()
-        self.x_pins_edit.setValidator(QIntValidator(1, 1000, self.x_pins_edit))
-        self.x_pins_edit.setText("1")
-        self.y_pins_edit = QLineEdit()
-        self.y_pins_edit.setValidator(QIntValidator(1, 1000, self.y_pins_edit))
-        self.y_pins_edit.setText("1")
+        # Use spin boxes so the user can increment/decrement with arrows
+        self.x_pins_edit = QSpinBox()
+        self.x_pins_edit.setRange(1, 1000)
+        self.x_pins_edit.setValue(1)
+        self.y_pins_edit = QSpinBox()
+        self.y_pins_edit.setRange(1, 1000)
+        self.y_pins_edit.setValue(1)
 
         # numbering pattern selector
         self.numbering_combo = QComboBox()
@@ -413,8 +415,11 @@ class ComponentInputDialog(QDialog):
         return {
             "component_name": self.name_edit.text().strip(),
             "function": self.function_combo.currentText(),
-            "x_pins": int(self.x_pins_edit.text() or 0),
-            "y_pins": int(self.y_pins_edit.text() or 0),
+            "part_number": self.part_number_edit.text().strip(),
+            "value": self.value_edit.text().strip(),
+            "package": self.package_edit.text().strip(),
+            "x_pins": int(self.x_pins_edit.value()),
+            "y_pins": int(self.y_pins_edit.value()),
             "number_scheme": self.numbering_combo.currentIndex(),  # 0-circular / 1-rows / 2-cols
             "test_side": self.side_combo.currentText().lower(),
             "testability": self.testability_combo.currentText(),
@@ -434,8 +439,11 @@ class ComponentInputDialog(QDialog):
             self.function_combo.itemText(i) for i in range(self.function_combo.count())
         ]:
             self.function_combo.setCurrentText(func)
-        self.x_pins_edit.setText(str(int(params.get("x_pins", 1))))
-        self.y_pins_edit.setText(str(int(params.get("y_pins", 1))))
+        self.part_number_edit.setText(params.get("part_number", ""))
+        self.value_edit.setText(params.get("value", ""))
+        self.package_edit.setText(params.get("package", ""))
+        self.x_pins_edit.setValue(int(params.get("x_pins", 1)))
+        self.y_pins_edit.setValue(int(params.get("y_pins", 1)))
         self.numbering_combo.setCurrentIndex(int(params.get("number_scheme", 0)))
         side = params.get("test_side", "top").capitalize()
         if side not in {"Top", "Bottom", "Both"}:

--- a/component_placer/quick_creation_controller.py
+++ b/component_placer/quick_creation_controller.py
@@ -217,6 +217,8 @@ class QuickCreationController(QObject):
         if self.last_params:
             prm = dict(self.last_params)
             prm["test_side"] = self.flags.get_flag("side", "top")
+            # Reset component name so auto-numbering works like normal placement
+            prm.pop("component_name", None)
             dlg.set_quick_params(prm)
         else:
             dlg.side_combo.setCurrentText(


### PR DESCRIPTION
## Summary
- make pin count widgets spinboxes
- include BOM fields in quick creation
- refresh component name when opening quick creation
- allow duplicate name cancel to reopen placement dialogs
- enlarge BOM editor window

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6853c20fd798832c9cac5030dfdfcdda