### PR TITLE
Implement quick creation improvements

### DIFF
--- a/component_placer/bom_handler/bom_editor_dialog.py
+++ b/component_placer/bom_handler/bom_editor_dialog.py
@@ -30,6 +30,8 @@ class BOMEditorDialog(QDialog):
         self.bom_handler = bom_handler
         self.board_set = board_component_names  # a set of board component names
         self.setWindowTitle("BOM Editor - Mismatch Fix")
+        # Make the dialog larger by default
+        self.resize(800, 600)
         
         # Compute mismatch sets (missing: on board not in BOM, extra: in BOM not on board)
         self.missing_set, self.extra_set = self._compute_mismatch()

--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -143,7 +143,9 @@ class ComponentPlacer(QObject):
         elif hasattr(self, "_move_channels") and self._move_channels:
             comp_name = self.footprint["pads"][0].get("component_name", "Unnamed")
             x_mm, y_mm = self.board_view.converter.pixels_to_mm(scene_x, scene_y)
-            self._finalize_footprint_placement(x_mm, y_mm, comp_name)
+            self._finalize_footprint_placement(
+                x_mm, y_mm, {"component_name": comp_name}
+            )
         else:
             # Create the input dialog and pass the shared BOMHandler so the dialog can update the BOM directly.
             dialog = ComponentInputDialog(bom_handler=self.bom_handler)
@@ -152,7 +154,17 @@ class ComponentPlacer(QObject):
                 self.project_manager.project_loaded_signal.connect(
                     dialog.reset_auto_numbering
                 )
-            if dialog.exec_() == dialog.Accepted:
+
+            params = None
+            while True:
+                if params:
+                    dialog.set_data(params)
+
+                if dialog.exec_() != dialog.Accepted:
+                    self.log.log("warning", "Placement canceled via input dialog.")
+                    self.deactivate_placement()
+                    return
+
                 input_data = dialog.get_data()
                 comp_name = input_data.get("component_name", "").strip()
                 if not comp_name:
@@ -161,13 +173,11 @@ class ComponentPlacer(QObject):
                     )
                     self.deactivate_placement()
                     return
-            else:
-                self.log.log("warning", "Placement canceled via input dialog.")
-                self.deactivate_placement()
-                return
 
-            x_mm, y_mm = self.board_view.converter.pixels_to_mm(scene_x, scene_y)
-            self._finalize_footprint_placement(x_mm, y_mm, comp_name)
+                x_mm, y_mm = self.board_view.converter.pixels_to_mm(scene_x, scene_y)
+                if self._finalize_footprint_placement(x_mm, y_mm, input_data):
+                    break
+                params = input_data
 
     def activate_placement(self, reset_orientation: bool = True):
         if not self.footprint:
@@ -245,7 +255,16 @@ class ComponentPlacer(QObject):
                 dialog.reset_auto_numbering
             )
 
-        if dialog.exec_() == dialog.Accepted:
+        params = None
+        while True:
+            if params:
+                dialog.set_data(params)
+
+            if dialog.exec_() != dialog.Accepted:
+                self.log.log("warning", "Placement canceled via input dialog.")
+                self.deactivate_placement()
+                return
+
             input_data = dialog.get_data()
             comp_name = input_data.get("component_name", "").strip()
             if not comp_name:
@@ -254,19 +273,17 @@ class ComponentPlacer(QObject):
                 )
                 self.deactivate_placement()
                 return
-        else:
-            self.log.log("warning", "Placement canceled via input dialog.")
-            self.deactivate_placement()
-            return
 
-        x_mm, y_mm = self.board_view.converter.pixels_to_mm(
-            scene_pos.x(), scene_pos.y()
-        )
-        self._finalize_footprint_placement(x_mm, y_mm, comp_name)
+            x_mm, y_mm = self.board_view.converter.pixels_to_mm(
+                scene_pos.x(), scene_pos.y()
+            )
+            if self._finalize_footprint_placement(x_mm, y_mm, input_data):
+                break
+            params = input_data
 
     def _finalize_footprint_placement(
-        self, x_mm: float, y_mm: float, initial_comp_name: str
-    ):
+        self, x_mm: float, y_mm: float, input_data: dict
+    ) -> bool:
 
         def transform_pad(pad):
             rad_val = radians(self.footprint_rotation)
@@ -340,21 +357,16 @@ class ComponentPlacer(QObject):
         is_move = hasattr(self, "_move_channels") and self._move_channels
 
         if is_move:
-            # MOVE MODE: We update existing objects in-place, then do a partial re-render via bulk_update_objects(...)
             comp_name = self.footprint["pads"][0].get(
-                "component_name", initial_comp_name
+                "component_name", input_data.get("component_name", "Unnamed")
             )
         else:
-            # Normal (new) placement logic
+            comp_name = input_data.get("component_name", "")
             comp_name_result, merge_choice, highest_pin, missing_pins = (
-                self._handle_duplicate_name_or_offset_pins(initial_comp_name)
+                self._handle_duplicate_name_or_offset_pins(comp_name)
             )
             if comp_name_result is None:
-                self.log.log(
-                    "warning", "Placement canceled due to duplicate name handling."
-                )
-                self.deactivate_placement()
-                return
+                return False
             user_comp_name = comp_name_result
             comp_name = user_comp_name
             if self.nod_file and os.path.exists(self.nod_file.nod_path):
@@ -482,6 +494,8 @@ class ComponentPlacer(QObject):
         if not is_move:
             # Optionally auto-reactivate so user can place another copy
             self.activate_placement(reset_orientation=False)
+
+        return True
 
     def _convert_objects_to_footprint(self, board_objects: List[BoardObject]) -> dict:
         if not board_objects:
@@ -702,17 +716,25 @@ class ComponentPlacer(QObject):
         pads_sorted = sorted(fp["pads"], key=lambda p: int(str(p["pin"])))
         input_name = self.quick_params.get("component_name", "QC-COMP")
 
-        comp_name_res, merge_choice, highest_pin, missing_pins = (
-            self._handle_duplicate_name_or_offset_pins(input_name)
-        )
-        if comp_name_res is None:
-            log.warning(
-                "[QC] placement canceled due to duplicate name dialog.",
-                module="QuickCreate",
-                func="place_quick",
+        while True:
+            comp_name_res, merge_choice, highest_pin, missing_pins = (
+                self._handle_duplicate_name_or_offset_pins(input_name)
             )
-            self.cancel_quick()
-            return
+            if comp_name_res is None:
+                dlg = ComponentInputDialog(parent=self.board_view.window(), quick=True)
+                dlg.set_quick_params(self.quick_params)
+                if dlg.exec_() != dlg.Accepted:
+                    log.warning(
+                        "[QC] placement canceled due to duplicate name dialog.",
+                        module="QuickCreate",
+                        func="place_quick",
+                    )
+                    self.cancel_quick()
+                    return
+                self.quick_params = dlg.get_quick_params()
+                input_name = self.quick_params.get("component_name", "QC-COMP")
+                continue
+            break
 
         comp_name = comp_name_res
         merge_counter = 1
@@ -796,11 +818,11 @@ class ComponentPlacer(QObject):
 
         if self.bom_handler:
             self.bom_handler.add_component(
-                self.quick_params["component_name"],
-                self.quick_params["function"],
-                "",
-                "",
-                "",
+                self.quick_params.get("component_name", ""),
+                self.quick_params.get("function", ""),
+                self.quick_params.get("value", ""),
+                self.quick_params.get("package", ""),
+                self.quick_params.get("part_number", ""),
             )
 
         if hasattr(self.board_view, "select_objects"):

--- a/component_placer/quick_creation_controller.py
+++ b/component_placer/quick_creation_controller.py
@@ -217,6 +217,8 @@ class QuickCreationController(QObject):
         if self.last_params:
             prm = dict(self.last_params)
             prm["test_side"] = self.flags.get_flag("side", "top")
+            # Reset component name so auto-numbering works like normal placement
+            prm.pop("component_name", None)
             dlg.set_quick_params(prm)
         else:
             dlg.side_combo.setCurrentText(


### PR DESCRIPTION
## Summary
- make pin count widgets spinboxes
- include BOM fields in quick creation
- refresh component name when opening quick creation
- allow duplicate name cancel to reopen placement dialogs
- enlarge BOM editor window
- handle partial float input in quick params
- return to same input dialog when duplicate name is cancelled

## Testing
- `pip install pre-commit` *(success)*
- `pre-commit run --files component_placer/component_input_dialog.py component_placer/component_placer.py` *(failed: pathspec v3.2.4 not found)*
- `black component_placer/component_input_dialog.py component_placer/component_placer.py`
- `pytest -q`
- `ruff check component_placer/component_input_dialog.py component_placer/component_placer.py`

------
https://chatgpt.com/codex/tasks/task_e_6853c20fd798832c9cac5030dfdfcdda