### PR TITLE
Implement quick creation improvements

### DIFF
--- a/component_placer/bom_handler/bom_editor_dialog.py
+++ b/component_placer/bom_handler/bom_editor_dialog.py
@@ -30,6 +30,8 @@ class BOMEditorDialog(QDialog):
         self.bom_handler = bom_handler
         self.board_set = board_component_names  # a set of board component names
         self.setWindowTitle("BOM Editor - Mismatch Fix")
+        # Make the dialog larger by default
+        self.resize(800, 600)
         
         # Compute mismatch sets (missing: on board not in BOM, extra: in BOM not on board)
         self.missing_set, self.extra_set = self._compute_mismatch()

--- a/component_placer/component_input_dialog.py
+++ b/component_placer/component_input_dialog.py
@@ -8,12 +8,13 @@ from PyQt5.QtWidgets import (
     QFormLayout,
     QHBoxLayout,
     QLineEdit,
+    QSpinBox,
     QComboBox,
     QCheckBox,
     QDialogButtonBox,
     QMessageBox,
 )
-from PyQt5.QtGui import QDoubleValidator, QIntValidator
+from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtCore import Qt, QSettings, pyqtSlot, pyqtSignal
 from logs.log_handler import LogHandler
 from component_placer.bom_handler.bom_handler import BOMHandler
@@ -40,9 +41,11 @@ class ComponentInputDialog(QDialog):
         logger=None,
         bom_handler: BOMHandler = None,
         quick: bool = False,
+        accept_callback=None,
     ):
         super().__init__(parent)
         self.quick_mode = quick
+        self.accept_callback = accept_callback
         self.setWindowTitle("New Component Details")
         self.setModal(True)
 
@@ -140,12 +143,13 @@ class ComponentInputDialog(QDialog):
         self.auto_numbering_checkbox.toggled.connect(self.update_component_name)
 
         # ── 2. QUICK-CREATION FIELDS ──────────────────────────────────────
-        self.x_pins_edit = QLineEdit()
-        self.x_pins_edit.setValidator(QIntValidator(1, 1000, self.x_pins_edit))
-        self.x_pins_edit.setText("1")
-        self.y_pins_edit = QLineEdit()
-        self.y_pins_edit.setValidator(QIntValidator(1, 1000, self.y_pins_edit))
-        self.y_pins_edit.setText("1")
+        # Use spin boxes so the user can increment/decrement with arrows
+        self.x_pins_edit = QSpinBox()
+        self.x_pins_edit.setRange(1, 1000)
+        self.x_pins_edit.setValue(1)
+        self.y_pins_edit = QSpinBox()
+        self.y_pins_edit.setRange(1, 1000)
+        self.y_pins_edit.setValue(1)
 
         # numbering pattern selector
         self.numbering_combo = QComboBox()
@@ -372,6 +376,9 @@ class ComponentInputDialog(QDialog):
         self.save_settings()
         data = self.get_data()
 
+        if self.accept_callback and not self.accept_callback(data):
+            return
+
         if self.bom_handler:
             # Directly update BOM if handler provided
             self.bom_handler.add_component(
@@ -401,6 +408,21 @@ class ComponentInputDialog(QDialog):
             "auto_numbering": self.auto_numbering_checkbox.isChecked(),
         }
 
+    def set_data(self, data: dict) -> None:
+        """Populate widgets from a classic component-data dictionary."""
+        self.name_edit.setText(data.get("component_name", ""))
+        func = data.get("function")
+        if func and func in [
+            self.function_combo.itemText(i) for i in range(self.function_combo.count())
+        ]:
+            self.function_combo.setCurrentText(func)
+        self.part_number_edit.setText(data.get("part_number", ""))
+        self.value_edit.setText(data.get("value", ""))
+        self.package_edit.setText(data.get("package", ""))
+        self.auto_prefix_checkbox.setChecked(data.get("auto_prefix", True))
+        self.auto_numbering_checkbox.setChecked(data.get("auto_numbering", False))
+        self.update_component_name()
+
     def get_quick_params(self) -> dict:
         """
         Collect all Quick-Creation parameters.
@@ -410,19 +432,25 @@ class ComponentInputDialog(QDialog):
 
         # Flush any un-committed editor text (LineEdits need no special handling)
 
+        self.x_pins_edit.interpretText()
+        self.y_pins_edit.interpretText()
+
         return {
             "component_name": self.name_edit.text().strip(),
             "function": self.function_combo.currentText(),
-            "x_pins": int(self.x_pins_edit.text() or 0),
-            "y_pins": int(self.y_pins_edit.text() or 0),
+            "part_number": self.part_number_edit.text().strip(),
+            "value": self.value_edit.text().strip(),
+            "package": self.package_edit.text().strip(),
+            "x_pins": int(self.x_pins_edit.value()),
+            "y_pins": int(self.y_pins_edit.value()),
             "number_scheme": self.numbering_combo.currentIndex(),  # 0-circular / 1-rows / 2-cols
             "test_side": self.side_combo.currentText().lower(),
             "testability": self.testability_combo.currentText(),
             "technology": self.tech_combo.currentText(),
             "shape": self.shape_combo.currentText(),
-            "width": float(self.width_edit.text() or 0.0),
-            "height": float(self.height_edit.text() or 0.0),
-            "hole": float(self.hole_edit.text() or 0.0),
+            "width": self._safe_float(self.width_edit.text()),
+            "height": self._safe_float(self.height_edit.text()),
+            "hole": self._safe_float(self.hole_edit.text()),
             "create_prefix": self.create_prefix_checkbox.isChecked(),
         }
 
@@ -434,8 +462,11 @@ class ComponentInputDialog(QDialog):
             self.function_combo.itemText(i) for i in range(self.function_combo.count())
         ]:
             self.function_combo.setCurrentText(func)
-        self.x_pins_edit.setText(str(int(params.get("x_pins", 1))))
-        self.y_pins_edit.setText(str(int(params.get("y_pins", 1))))
+        self.part_number_edit.setText(params.get("part_number", ""))
+        self.value_edit.setText(params.get("value", ""))
+        self.package_edit.setText(params.get("package", ""))
+        self.x_pins_edit.setValue(int(params.get("x_pins", 1)))
+        self.y_pins_edit.setValue(int(params.get("y_pins", 1)))
         self.numbering_combo.setCurrentIndex(int(params.get("number_scheme", 0)))
         side = params.get("test_side", "top").capitalize()
         if side not in {"Top", "Bottom", "Both"}:
@@ -461,6 +492,14 @@ class ComponentInputDialog(QDialog):
             lbl = self.form_layout.labelForField(w)
             if lbl:
                 lbl.setVisible(show)
+
+    @staticmethod
+    def _safe_float(text: str) -> float:
+        """Return float(text) but fall back to 0.0 on ValueError."""
+        try:
+            return float(text)
+        except (TypeError, ValueError):
+            return 0.0
 
     def _emit_live(self, *args):
         """Emit quick_params_changed with the current params."""


### PR DESCRIPTION
## Summary
- make pin count widgets spinboxes
- include BOM fields in quick creation
- refresh component name when opening quick creation
- allow duplicate name cancel to reopen placement dialogs
- enlarge BOM editor window
- handle partial float input in quick params
- return to same input dialog when duplicate name is cancelled
- reuse existing dialog on quick creation duplicate cancel

## Testing
- `pip install pre-commit` *(success)*
- `pre-commit run --files component_placer/component_input_dialog.py component_placer/component_placer.py` *(failed: pathspec v3.2.4 not found)*
- `black component_placer/component_input_dialog.py component_placer/component_placer.py`
- `pytest -q`
- `ruff check component_placer/component_input_dialog.py component_placer/component_placer.py`


------
https://chatgpt.com/codex/tasks/task_e_6853c20fd798832c9cac5030dfdfcdda