### PR TITLE
Add automatic project creation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ python main.py
 * 📸 **Pad digitisation GUI** – place pads, anchors, component footprints on high‑res board images  
 * 📊 **BOM / ALF verifier** – highlight mismatches between schematic and physical layout  
 * 🛠 **Quick placer & ghost overlay** – rapid placement with row/column logic and visual feedback  
-* 🔥 **Laser‑solder thermal simulator** – predict optimal power/time for through‑hole pads  
-* 🔌 **Protocol helpers** – SPI / MDIO scripting utilities and packet logger  
+* 🔌 **Protocol helpers** – SPI / MDIO scripting utilities and packet logger
 * 🧰 **Extensible plugin architecture** – add new component libraries or exporters easily
+
+## Creating Projects
+
+Choose **Create Project** from the menu and select either:
+
+* **Manual** – pick images and fill in settings yourself.
+* **Automatic** – select a VIVA `.mdb` file and the tool loads images and coordinates for you (an "Uploading data" dialog will appear).
 
 ## Roadmap
 

--- a/ui/create_project_mode_dialog.py
+++ b/ui/create_project_mode_dialog.py
@@ -1,0 +1,13 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QPushButton, QLabel
+
+
+class CreateProjectModeDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Create Project")
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Select creation mode:"))
+        self.manual_button = QPushButton("Manual")
+        self.auto_button = QPushButton("Automatic from MDB")
+        layout.addWidget(self.manual_button)
+        layout.addWidget(self.auto_button)


### PR DESCRIPTION
## Summary
- update README: remove laser solder mention and document creation options
- add dialog for choosing manual or automatic project creation
- implement automatic workflow driven by MDB file
- wrap existing manual workflow

## Testing
- `ruff check .` *(fails: unrecognized subcommand)*
- `pytest -q`
- `black . --check` *(fails: many files would be reformatted)*

------
https://chatgpt.com/codex/tasks/task_e_6853fd391b84832cbeb48b2329f0305d