### PR TITLE
Ensure move and edit actions push undo state

### DIFF
--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -402,23 +402,24 @@ class ComponentPlacer(QObject):
                     self.log.log("warning", f"No object found for channel {ch}.")
                     continue
 
-                # --------- 1) update live fields ----------
-                orig_obj.x_coord_mm = pos_x
-                orig_obj.y_coord_mm = pos_y
-                orig_obj.angle_deg = final_angle
-                orig_obj.test_position = side  # keep side in sync
+                # Create a copy so we don't mutate the library before push_state
+                obj_copy = copy.deepcopy(orig_obj)
 
-                # --------- 2) sync backup fields ----------
-                # Most save / export code serialises the “_original” attrs
-                # if they exist, so keep them coherent:
+                # --------- 1) update live fields on the copy ----------
+                obj_copy.x_coord_mm = pos_x
+                obj_copy.y_coord_mm = pos_y
+                obj_copy.angle_deg = final_angle
+                obj_copy.test_position = side  # keep side in sync
+
+                # --------- 2) sync backup fields on the copy ----------
                 for attr_name, value in (
                     ("x_coord_mm_original", pos_x),
                     ("y_coord_mm_original", pos_y),
                     ("angle_deg_original", final_angle),
                 ):
-                    setattr(orig_obj, attr_name, value)
+                    setattr(obj_copy, attr_name, value)
 
-                updates.append(orig_obj)
+                updates.append(obj_copy)
 
             # Push the mutations through the partial-render path
             if updates:

--- a/edit_pads/pad_editor_dialog.py
+++ b/edit_pads/pad_editor_dialog.py
@@ -1,4 +1,5 @@
 import time
+import copy
 from typing import List, Optional
 from PyQt5.QtWidgets import (
     QDialog, QTableWidget, QTableWidgetItem, QVBoxLayout, QHBoxLayout,
@@ -514,13 +515,14 @@ class PadEditorDialog(QDialog):
         for row in range(self.pad_table.rowCount()):
             pad = self.get_pad_for_row(row)
             if pad and pad.channel in selected_channels:
+                pad_copy = copy.deepcopy(pad)
                 modified = False
                 for attr, val in changes.items():
-                    if getattr(pad, attr, None) != val:
-                        setattr(pad, attr, val)
+                    if getattr(pad_copy, attr, None) != val:
+                        setattr(pad_copy, attr, val)
                         modified = True
                 if modified:
-                    updated_pads.append(pad)
+                    updated_pads.append(pad_copy)
 
         if not updated_pads:
             QMessageBox.information(self, "No Changes",
@@ -532,6 +534,13 @@ class PadEditorDialog(QDialog):
         # ------------------------------------------------------------------
         if self.object_library:
             self.object_library.bulk_update_objects(updated_pads, changes)
+            channel_map = {obj.channel: obj for obj in updated_pads}
+            self.selected_pads = [
+                channel_map.get(p.channel, p) for p in self.selected_pads
+            ]
+            self.filtered_pads = [
+                channel_map.get(p.channel, p) for p in self.filtered_pads
+            ]
 
         # ------------------------------------------------------------------
         # STEP 4 – refresh table *and* restore multi-row selection

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import copy
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont, QDoubleValidator
 from PyQt5.QtWidgets import (
@@ -550,14 +551,15 @@ class MainWindow(QMainWindow):
             return
         updates = []
         for obj in self.object_library.get_all_objects():
-            obj.x_coord_mm += dx
-            obj.y_coord_mm += dy
+            obj_copy = copy.deepcopy(obj)
+            obj_copy.x_coord_mm += dx
+            obj_copy.y_coord_mm += dy
             # keep “original” coords too, if they exist
-            if hasattr(obj, "x_coord_mm_original"):
-                obj.x_coord_mm_original += dx
-            if hasattr(obj, "y_coord_mm_original"):
-                obj.y_coord_mm_original += dy
-            updates.append(obj)
+            if hasattr(obj_copy, "x_coord_mm_original"):
+                obj_copy.x_coord_mm_original += dx
+            if hasattr(obj_copy, "y_coord_mm_original"):
+                obj_copy.y_coord_mm_original += dy
+            updates.append(obj_copy)
         self.object_library.bulk_update_objects(updates, {})
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep undo history intact by copying objects before move/bulk updates
- use deep copies when shifting pads or editing pads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685529872a78832c8face3b6bd8f0437