### PR TITLE
Ensure move and edit actions push undo state

### DIFF
--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -402,23 +402,24 @@ class ComponentPlacer(QObject):
                     self.log.log("warning", f"No object found for channel {ch}.")
                     continue
 
-                # --------- 1) update live fields ----------
-                orig_obj.x_coord_mm = pos_x
-                orig_obj.y_coord_mm = pos_y
-                orig_obj.angle_deg = final_angle
-                orig_obj.test_position = side  # keep side in sync
+                # Create a copy so we don't mutate the library before push_state
+                obj_copy = copy.deepcopy(orig_obj)
 
-                # --------- 2) sync backup fields ----------
-                # Most save / export code serialises the “_original” attrs
-                # if they exist, so keep them coherent:
+                # --------- 1) update live fields on the copy ----------
+                obj_copy.x_coord_mm = pos_x
+                obj_copy.y_coord_mm = pos_y
+                obj_copy.angle_deg = final_angle
+                obj_copy.test_position = side  # keep side in sync
+
+                # --------- 2) sync backup fields on the copy ----------
                 for attr_name, value in (
                     ("x_coord_mm_original", pos_x),
                     ("y_coord_mm_original", pos_y),
                     ("angle_deg_original", final_angle),
                 ):
-                    setattr(orig_obj, attr_name, value)
+                    setattr(obj_copy, attr_name, value)
 
-                updates.append(orig_obj)
+                updates.append(obj_copy)
 
             # Push the mutations through the partial-render path
             if updates:

--- a/edit_pads/pad_editor_dialog.py
+++ b/edit_pads/pad_editor_dialog.py
@@ -1,4 +1,5 @@
 import time
+import copy
 from typing import List, Optional
 from PyQt5.QtWidgets import (
     QDialog, QTableWidget, QTableWidgetItem, QVBoxLayout, QHBoxLayout,
@@ -514,13 +515,14 @@ class PadEditorDialog(QDialog):
         for row in range(self.pad_table.rowCount()):
             pad = self.get_pad_for_row(row)
             if pad and pad.channel in selected_channels:
+                pad_copy = copy.deepcopy(pad)
                 modified = False
                 for attr, val in changes.items():
-                    if getattr(pad, attr, None) != val:
-                        setattr(pad, attr, val)
+                    if getattr(pad_copy, attr, None) != val:
+                        setattr(pad_copy, attr, val)
                         modified = True
                 if modified:
-                    updated_pads.append(pad)
+                    updated_pads.append(pad_copy)
 
         if not updated_pads:
             QMessageBox.information(self, "No Changes",
@@ -532,6 +534,13 @@ class PadEditorDialog(QDialog):
         # ------------------------------------------------------------------
         if self.object_library:
             self.object_library.bulk_update_objects(updated_pads, changes)
+            channel_map = {obj.channel: obj for obj in updated_pads}
+            self.selected_pads = [
+                channel_map.get(p.channel, p) for p in self.selected_pads
+            ]
+            self.filtered_pads = [
+                channel_map.get(p.channel, p) for p in self.filtered_pads
+            ]
 
         # ------------------------------------------------------------------
         # STEP 4 – refresh table *and* restore multi-row selection

--- a/objects/search_library.py
+++ b/objects/search_library.py
@@ -17,10 +17,12 @@ class SearchLibrary:
         """
         self.log.log("debug", f"Searching for pad with Component: {component}, Pin: {pin}, Signal: {signal}, Channel: {channel}")
         for obj in self.object_library.get_all_objects():
-            if (obj.component_name.lower() == component.lower() and
-                str(obj.pin) == pin and
-                obj.signal.lower() == signal.lower() and
-                obj.channel == channel):
+            if (
+                obj.component_name == component
+                and str(obj.pin) == pin
+                and obj.signal == signal
+                and obj.channel == channel
+            ):
                 self.log.log("info", f"Pad found: {obj}")
                 self.log.log("debug", f"Pad coordinates: x={obj.x_coord_mm}, y={obj.y_coord_mm}")
                 return obj
@@ -34,7 +36,7 @@ class SearchLibrary:
         """
         self.log.log("debug", f"Searching for pad with Signal: {signal}")
         for obj in self.object_library.get_all_objects():
-            if obj.signal.lower() == signal.lower():
+            if obj.signal == signal:
                 self.log.log("info", f"Pad found by signal: {obj}")
                 return obj
         self.log.log("warning", f"No pad found for Signal: {signal}")
@@ -65,8 +67,13 @@ class SearchLibrary:
         """
         Retrieves a list of pins for the specified component.
         """
-        pins = sorted({str(obj.pin) for obj in self.object_library.get_all_objects()
-                      if obj.component_name.lower() == component.lower()})
+        pins = sorted(
+            {
+                str(obj.pin)
+                for obj in self.object_library.get_all_objects()
+                if obj.component_name == component
+            }
+        )
         self.log.log("debug", f"Retrieved pins for component '{component}': {pins}")
         return pins
 
@@ -74,8 +81,13 @@ class SearchLibrary:
         """
         Retrieves a list of signals for the specified component and pin.
         """
-        signals = sorted({obj.signal for obj in self.object_library.get_all_objects()
-                          if obj.component_name.lower() == component.lower() and str(obj.pin) == pin})
+        signals = sorted(
+            {
+                obj.signal
+                for obj in self.object_library.get_all_objects()
+                if obj.component_name == component and str(obj.pin) == pin
+            }
+        )
         self.log.log("debug", f"Retrieved signals for component '{component}' and pin '{pin}': {signals}")
         return signals
 
@@ -83,9 +95,16 @@ class SearchLibrary:
         """
         Retrieves a list of channels for the specified component, pin, and signal.
         """
-        channels = sorted({str(obj.channel) for obj in self.object_library.get_all_objects()
-                           if (obj.component_name.lower() == component.lower() and
-                               str(obj.pin) == pin and
-                               obj.signal.lower() == signal.lower())})
+        channels = sorted(
+            {
+                str(obj.channel)
+                for obj in self.object_library.get_all_objects()
+                if (
+                    obj.component_name == component
+                    and str(obj.pin) == pin
+                    and obj.signal == signal
+                )
+            }
+        )
         self.log.log("debug", f"Retrieved channels for component '{component}', pin '{pin}', signal '{signal}': {channels}")
         return channels

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import copy
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont, QDoubleValidator
 from PyQt5.QtWidgets import (
@@ -550,14 +551,15 @@ class MainWindow(QMainWindow):
             return
         updates = []
         for obj in self.object_library.get_all_objects():
-            obj.x_coord_mm += dx
-            obj.y_coord_mm += dy
+            obj_copy = copy.deepcopy(obj)
+            obj_copy.x_coord_mm += dx
+            obj_copy.y_coord_mm += dy
             # keep “original” coords too, if they exist
-            if hasattr(obj, "x_coord_mm_original"):
-                obj.x_coord_mm_original += dx
-            if hasattr(obj, "y_coord_mm_original"):
-                obj.y_coord_mm_original += dy
-            updates.append(obj)
+            if hasattr(obj_copy, "x_coord_mm_original"):
+                obj_copy.x_coord_mm_original += dx
+            if hasattr(obj_copy, "y_coord_mm_original"):
+                obj_copy.y_coord_mm_original += dy
+            updates.append(obj_copy)
         self.object_library.bulk_update_objects(updates, {})
 
     # --------------------------------------------------------------------------

--- a/ui/search_dialog.py
+++ b/ui/search_dialog.py
@@ -50,7 +50,7 @@ class SearchDialog(QDialog):
         self.component_line_edit.setPlaceholderText("Enter component")
         self.comp_model = QStringListModel([])
         self.comp_completer = QCompleter(self.comp_model, self)
-        self.comp_completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self.comp_completer.setCaseSensitivity(Qt.CaseSensitive)
         self.component_line_edit.setCompleter(self.comp_completer)
         self.comp_error_action = self.component_line_edit.addAction(error_icon, QLineEdit.TrailingPosition)
         self.comp_error_action.setVisible(False)
@@ -66,7 +66,7 @@ class SearchDialog(QDialog):
         self.pin_line_edit.setEnabled(False)
         self.pin_model = QStringListModel([])
         self.pin_completer = QCompleter(self.pin_model, self)
-        self.pin_completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self.pin_completer.setCaseSensitivity(Qt.CaseSensitive)
         self.pin_line_edit.setCompleter(self.pin_completer)
         self.pin_error_action = self.pin_line_edit.addAction(error_icon, QLineEdit.TrailingPosition)
         self.pin_error_action.setVisible(False)
@@ -81,7 +81,7 @@ class SearchDialog(QDialog):
         self.signal_line_edit.setPlaceholderText("Enter signal")
         self.signal_model = QStringListModel([])
         self.signal_completer = QCompleter(self.signal_model, self)
-        self.signal_completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self.signal_completer.setCaseSensitivity(Qt.CaseSensitive)
         self.signal_line_edit.setCompleter(self.signal_completer)
         self.signal_error_action = self.signal_line_edit.addAction(error_icon, QLineEdit.TrailingPosition)
         self.signal_error_action.setVisible(False)
@@ -96,7 +96,7 @@ class SearchDialog(QDialog):
         self.channel_line_edit.setPlaceholderText("Enter channel")
         self.channel_model = QStringListModel([])
         self.channel_completer = QCompleter(self.channel_model, self)
-        self.channel_completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self.channel_completer.setCaseSensitivity(Qt.CaseSensitive)
         self.channel_line_edit.setCompleter(self.channel_completer)
         self.channel_error_action = self.channel_line_edit.addAction(error_icon, QLineEdit.TrailingPosition)
         self.channel_error_action.setVisible(False)
@@ -188,7 +188,7 @@ class SearchDialog(QDialog):
         valid = False
         if field == "component":
             valid_list = self.comp_model.stringList()
-            valid = any(item.lower() == text.lower() for item in valid_list)
+            valid = text in valid_list
             self.comp_error_action.setVisible(not valid)
             self.component_line_edit.setStyleSheet("" if valid else "border: 1px solid red;")
         elif field == "pin":
@@ -229,14 +229,27 @@ class SearchDialog(QDialog):
 
         # Query candidate pads based on the driver field.
         if driver == "component":
-            candidates = [pad for pad in self.search_library.object_library.get_all_objects()
-                          if pad.component_name.lower().startswith(comp_text.lower())]
+            candidates = [
+                pad
+                for pad in self.search_library.object_library.get_all_objects()
+                if pad.component_name.startswith(comp_text)
+            ]
         elif driver == "pin":
-            candidates = [] if not comp_text else [pad for pad in self.search_library.object_library.get_all_objects()
-                          if pad.component_name.lower() == comp_text.lower() and str(pad.pin).startswith(pin_text)]
+            candidates = (
+                []
+                if not comp_text
+                else [
+                    pad
+                    for pad in self.search_library.object_library.get_all_objects()
+                    if pad.component_name == comp_text and str(pad.pin).startswith(pin_text)
+                ]
+            )
         elif driver == "signal":
-            candidates = [pad for pad in self.search_library.object_library.get_all_objects()
-                          if pad.signal and pad.signal.lower().startswith(signal_text.lower())]
+            candidates = [
+                pad
+                for pad in self.search_library.object_library.get_all_objects()
+                if pad.signal and pad.signal.startswith(signal_text)
+            ]
         elif driver == "channel":
             candidates = [pad for pad in self.search_library.object_library.get_all_objects()
                           if pad.channel is not None and str(pad.channel).startswith(channel_text)]
@@ -311,7 +324,7 @@ class SearchDialog(QDialog):
                 continue
             if 'pin' in criteria and str(pad.pin) != criteria['pin']:
                 continue
-            if 'signal' in criteria and (not pad.signal or pad.signal.lower() != criteria['signal'].lower()):
+            if 'signal' in criteria and (not pad.signal or pad.signal != criteria['signal']):
                 continue
             if 'channel' in criteria:
                 if isinstance(criteria['channel'], int):


### PR DESCRIPTION
## Summary
- keep undo history intact by copying objects before move/bulk updates
- use deep copies when shifting pads or editing pads
- make search fields case sensitive and update validation accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685529872a78832c8face3b6bd8f0437