### PR TITLE
Persist backup folder selection and note windowed build

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ pyinstaller --noconfirm --onedir \
     --add-data "constants:constants" \
     --add-data "component_libraries:component_libraries" \
     --icon=icon.ico \
+    --windowed \
     --name Digitation main.py
 ```
+
+Including the `--windowed` option ensures no console window appears when
+running the resulting executable under Windows.
 
 The resulting `dist/Digitation` directory contains the application along with
 `constants/constants.txt`, `constants/functions_ref.txt` and the


### PR DESCRIPTION
## Summary
- show a tiny progress dialog while locating the backup folder
- persist the chosen backup directory in constants
- document how to build without a console window

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855a79145ac832c989dcb81e1ed063f