### PR TITLE
Fix auto-save call and add unit test

### DIFF
--- a/project_manager/project_manager.py
+++ b/project_manager/project_manager.py
@@ -118,7 +118,7 @@ class ProjectManager(QObject):
                 f"Auto-saving project to {nod_path} after {self.auto_save_counter} bulk actions.",
             )
             nod_file = BoardNodFile(nod_path, object_library=self.object_library)
-            nod_file.save_with_logging(logger=self.log)
+            nod_file.save(backup=True, logger=self.log)
             self.auto_save_counter = 0
         else:
             self.log.log("warning", "Auto-save skipped: No valid project folder.")

--- a/tests/test_auto_save.py
+++ b/tests/test_auto_save.py
@@ -1,0 +1,33 @@
+import builtins
+from types import SimpleNamespace
+import os
+
+from logs.log_handler import LogHandler
+from objects.object_library import ObjectLibrary
+from project_manager.project_manager import ProjectManager
+from component_placer.bom_handler.bom_handler import BOMHandler
+from objects.nod_file import BoardNodFile
+
+
+def test_auto_save_trigger(tmp_path, monkeypatch):
+    log = LogHandler()
+    obj_lib = ObjectLibrary()
+    main_window = SimpleNamespace(log=log, object_library=obj_lib, current_project_path=str(tmp_path))
+    pm = ProjectManager(main_window, bom_handler=BOMHandler())
+    pm.project_loaded = True
+    pm.auto_save_threshold = 2
+
+    saved = {"count": 0}
+
+    def fake_save(self, backup=False, logger=None, fixed_ts=None):
+        saved["count"] += 1
+        return True
+
+    monkeypatch.setattr(BoardNodFile, "save", fake_save)
+    monkeypatch.setattr(BoardNodFile, "save_with_logging", fake_save, raising=False)
+
+    pm.handle_bulk_operation_completed("Bulk Add")
+    assert saved["count"] == 0
+    pm.handle_bulk_operation_completed("Bulk Add")
+    assert saved["count"] == 1
+    assert pm.auto_save_counter == 0


### PR DESCRIPTION
## Summary
- fix `auto_save()` to use `BoardNodFile.save`
- add test covering auto-save triggering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856774b59ac832c9f46a1ae89d24c78