### PR TITLE
Fix autosave signal deadlock

### DIFF
--- a/objects/object_library.py
+++ b/objects/object_library.py
@@ -200,7 +200,9 @@ class ObjectLibrary(QObject):
                 self.display_library.add_rendered_objects(added_objects)
 
             self.log.log("info", f"bulk_add: Added {len(added_objects)} objects.")
-            self.bulk_operation_completed.emit("Bulk Add")
+
+        # Emit after releasing the mutex to avoid deadlocks during auto-save
+        self.bulk_operation_completed.emit("Bulk Add")
 
     # Remove or leave a no-op save() method since auto-save is not desired.
     def save(self):
@@ -308,14 +310,14 @@ class ObjectLibrary(QObject):
                 if deleted_channels:
                     self.display_library.remove_rendered_objects(deleted_channels)
 
-            # Emit bulk operation signal for auto-save logic
-            self.bulk_operation_completed.emit("Bulk Modify")
-
             self.log.log(
                 "info",
                 f"modify_objects => Added={len(added)}, Updated={len(updated)}, "
                 f"Deleted={len(deleted)}",
             )
+
+        # Emit after releasing the mutex to avoid deadlocks during auto-save
+        self.bulk_operation_completed.emit("Bulk Modify")
 
     def bulk_delete(self, channels_to_remove: List[int]) -> None:
         """
@@ -338,7 +340,9 @@ class ObjectLibrary(QObject):
             self.log.log(
                 "info", f"bulk_delete: Deleted {len(removed_channels)} objects."
             )
-            self.bulk_operation_completed.emit("Bulk Delete")
+
+        # Emit after releasing the mutex to avoid deadlocks during auto-save
+        self.bulk_operation_completed.emit("Bulk Delete")
 
     def bulk_update_objects(self, updates: List[BoardObject], changes: dict) -> None:
         """
@@ -360,4 +364,6 @@ class ObjectLibrary(QObject):
             self.log.log(
                 "info", f"bulk_update_objects: Updated {len(updates)} objects."
             )
-            self.bulk_operation_completed.emit("Bulk Update")
+
+        # Emit after releasing the mutex to avoid deadlocks during auto-save
+        self.bulk_operation_completed.emit("Bulk Update")

--- a/tests/test_auto_save.py
+++ b/tests/test_auto_save.py
@@ -1,0 +1,76 @@
+import builtins
+from types import SimpleNamespace
+import os
+
+from logs.log_handler import LogHandler
+from objects.object_library import ObjectLibrary
+from project_manager.project_manager import ProjectManager
+from component_placer.bom_handler.bom_handler import BOMHandler
+from objects.nod_file import BoardNodFile
+
+
+def test_auto_save_trigger(tmp_path, monkeypatch):
+    log = LogHandler()
+    obj_lib = ObjectLibrary()
+    constants = SimpleNamespace(
+        get=lambda k, d=None: d, set=lambda k, v: None, save=lambda: None
+    )
+    main_window = SimpleNamespace(
+        log=log,
+        object_library=obj_lib,
+        current_project_path=str(tmp_path),
+        constants=constants,
+    )
+    pm = ProjectManager(main_window, bom_handler=BOMHandler())
+    pm.project_loaded = True
+    pm.auto_save_threshold = 2
+
+    saved = {"count": 0}
+
+    def fake_save(self, backup=False, logger=None, fixed_ts=None):
+        saved["count"] += 1
+        return True
+
+    monkeypatch.setattr(BoardNodFile, "save", fake_save)
+    monkeypatch.setattr(BoardNodFile, "save_with_logging", fake_save, raising=False)
+
+    pm.handle_bulk_operation_completed("Bulk Add")
+    assert saved["count"] == 0
+    pm.handle_bulk_operation_completed("Bulk Add")
+    assert saved["count"] == 1
+    assert pm.auto_save_counter == 0
+
+
+def test_auto_save_via_object_library(tmp_path, monkeypatch):
+    log = LogHandler()
+    obj_lib = ObjectLibrary()
+    constants = SimpleNamespace(
+        get=lambda k, d=None: d, set=lambda k, v: None, save=lambda: None
+    )
+    main_window = SimpleNamespace(
+        log=log,
+        object_library=obj_lib,
+        current_project_path=str(tmp_path),
+        constants=constants,
+    )
+    pm = ProjectManager(main_window, bom_handler=BOMHandler())
+    pm.project_loaded = True
+    pm.auto_save_threshold = 2
+
+    saved = {"count": 0}
+
+    def fake_save(self, backup=False, logger=None, fixed_ts=None):
+        saved["count"] += 1
+        return True
+
+    monkeypatch.setattr(BoardNodFile, "save", fake_save)
+
+    from objects.board_object import BoardObject
+
+    obj = BoardObject("C1", 1)
+
+    obj_lib.bulk_add([obj], skip_render=True)
+    assert saved["count"] == 0
+    obj_lib.bulk_add([obj], skip_render=True)
+    assert saved["count"] == 1
+    assert pm.auto_save_counter == 0


### PR DESCRIPTION
## Summary
- avoid holding the object library mutex when emitting bulk-operation signals
- extend the auto-save test to simulate operations via `ObjectLibrary`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856774b59ac832c9f46a1ae89d24c78