### PR TITLE
Prompt backup dir selection

### DIFF
--- a/constants/constants.txt
+++ b/constants/constants.txt
@@ -23,7 +23,7 @@
     "BottomImageYCoord": 0.0,
     "TopImageXCoord": 0.0,
     "TopImageYCoord": 0.0,
-    "central_backup_dir": "Z:/Project Management/Seica/other/Digitation_backups",
+    "central_backup_dir": "",
     "max_backups": 5,
     "anchor_nudge_step_mm": 0.2,
     "max_zoom": 10.0,

--- a/ui/board_view/board_view.py
+++ b/ui/board_view/board_view.py
@@ -412,7 +412,6 @@ class BoardView(QGraphicsView):
                 follow_mouse=follow_mouse,
             )
 
-
     def fit_in_view(self):
         if not self.current_pixmap_item:
             self.log.log("warning", "No current pixmap item to fit.")
@@ -516,7 +515,6 @@ class BoardView(QGraphicsView):
         paste_action = QAction("Paste", self)
         delete_action = QAction("Delete", self)
         edit_action = QAction("Edit", self)
-        list_action = QAction("List Selected Pads", self)
         cut_action = QAction("Cut", self)
         move_action = QAction("Move", self)
 
@@ -532,7 +530,6 @@ class BoardView(QGraphicsView):
         edit_action.triggered.connect(
             lambda: actions.edit_pads(self.object_library, selected_pads)
         )
-        list_action.triggered.connect(lambda: actions.list_pads(selected_pads))
         cut_action.triggered.connect(
             lambda: actions.cut_pads(self.object_library, selected_pads)
         )
@@ -555,8 +552,6 @@ class BoardView(QGraphicsView):
         menu.addAction(move_action)
         menu.addAction(delete_action)
         menu.addAction(edit_action)
-        menu.addSeparator()
-        menu.addAction(list_action)
         menu.addSeparator()
         menu.addAction(export_footprint_action)  # <-- new
 
@@ -754,14 +749,6 @@ class BoardView(QGraphicsView):
             self.log.log("warning", "No pads selected to edit.")
             return
         actions.edit_pads(self.object_library, selected_pads)
-
-    def list_selected_pads(self):
-        """Handles Ctrl+L (List)"""
-        selected_pads = self._get_selected_pads()
-        if not selected_pads:
-            self.log.log("warning", "No pads selected to list.")
-            return
-        actions.list_pads(selected_pads)
 
     def cut_selected_pads(self):
         """Handles Ctrl+X (Cut)"""

--- a/ui/board_view/shortcuts.py
+++ b/ui/board_view/shortcuts.py
@@ -3,6 +3,7 @@ from PyQt5.QtWidgets import QShortcut
 from PyQt5.QtGui import QKeySequence
 from PyQt5.QtCore import Qt
 
+
 def setup_board_view_shortcuts(board_view):
     board_view.save_shortcut = QShortcut(QKeySequence("Ctrl+S"), board_view)
     board_view.save_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
@@ -11,7 +12,7 @@ def setup_board_view_shortcuts(board_view):
     board_view.save_shortcut.activated.connect(
         lambda: board_view.parent().project_manager.save_project_dialog()
     )
-    
+
     board_view.copy_shortcut = QShortcut(QKeySequence("Ctrl+C"), board_view)
     board_view.copy_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
     board_view.copy_shortcut.activated.connect(board_view.copy_selected_pads)
@@ -28,10 +29,6 @@ def setup_board_view_shortcuts(board_view):
     board_view.edit_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
     board_view.edit_shortcut.activated.connect(board_view.edit_selected_pads)
 
-    board_view.list_shortcut = QShortcut(QKeySequence("Ctrl+L"), board_view)
-    board_view.list_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
-    board_view.list_shortcut.activated.connect(board_view.list_selected_pads)
-
     board_view.undo_shortcut = QShortcut(QKeySequence("Ctrl+Z"), board_view)
     board_view.undo_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
     board_view.undo_shortcut.activated.connect(board_view.perform_undo)
@@ -40,14 +37,18 @@ def setup_board_view_shortcuts(board_view):
     board_view.redo_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
     board_view.redo_shortcut.activated.connect(board_view.perform_redo)
 
-    board_view.switch_side_shortcut = QShortcut(QKeySequence("Ctrl+Shift+S"), board_view)
+    board_view.switch_side_shortcut = QShortcut(
+        QKeySequence("Ctrl+Shift+S"), board_view
+    )
     board_view.switch_side_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
     board_view.switch_side_shortcut.activated.connect(board_view.switch_side)
 
     board_view.search_shortcut = QShortcut(QKeySequence("Ctrl+F"), board_view)
     board_view.search_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
     # Assume that MainWindow provides an open_search_dialog() method:
-    board_view.search_shortcut.activated.connect(lambda: board_view.parent().open_search_dialog())
+    board_view.search_shortcut.activated.connect(
+        lambda: board_view.parent().open_search_dialog()
+    )
 
     board_view.cut_shortcut = QShortcut(QKeySequence("Ctrl+X"), board_view)
     board_view.cut_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
@@ -56,7 +57,7 @@ def setup_board_view_shortcuts(board_view):
     board_view.move_shortcut = QShortcut(QKeySequence("Ctrl+M"), board_view)
     board_view.move_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
     board_view.move_shortcut.activated.connect(board_view.move_selected_pads)
-    
+
     #  Flip ghost horizontally  (Ctrl+H)
     board_view.flip_shortcut = QShortcut(QKeySequence("Ctrl+H"), board_view)
     board_view.flip_shortcut.setContext(Qt.WidgetWithChildrenShortcut)

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -126,6 +126,10 @@ class MainWindow(QMainWindow):
         # ─── Show window ────────────────────────────────────────────────
         self.show()
 
+        # Prompt for backup folder on first run
+        if not str(self.constants.get("central_backup_dir") or "").strip():
+            self.choose_backup_folder()
+
         # ─── Startup dialog to open or create a project ──────────────────
         start_dlg = StartDialog(self)
 
@@ -436,6 +440,10 @@ class MainWindow(QMainWindow):
         choose_backup_action.triggered.connect(self.choose_backup_folder)
         backup_menu.addAction(choose_backup_action)
 
+        set_max_backups_action = QAction("Set Max Backups", self)
+        set_max_backups_action.triggered.connect(self.set_max_backups)
+        backup_menu.addAction(set_max_backups_action)
+
         # ----- Board Settings submenu -----
         board_menu = properties_menu.addMenu("Board Settings")
         set_mm_per_pixels_top_action = QAction("Set mm_per_pixels_top", self)
@@ -465,8 +473,6 @@ class MainWindow(QMainWindow):
         set_prefix_table_action = QAction("Set Quick Prefix Table", self)
         set_prefix_table_action.triggered.connect(self.set_quick_prefix_table)
         prefix_menu.addAction(set_prefix_table_action)
-
-
 
     # ------------------------------------------------------------------
     #  Board Origin Setter
@@ -955,6 +961,22 @@ class MainWindow(QMainWindow):
 
         self.constants.set("central_backup_dir", new_dir)
         self.constants.save()
+
+    def set_max_backups(self):
+        """Prompt user to set the maximum number of backup files."""
+        current_value = int(self.constants.get("max_backups", 5) or 5)
+        value, ok = QInputDialog.getInt(
+            self,
+            "Max Backups",
+            "Enter maximum number of backup files to keep:",
+            current_value,
+            1,
+            100,
+        )
+        if ok:
+            self.constants.set("max_backups", value)
+            self.constants.save()
+            self.log.log("info", f"Max backups set to {value}")
 
     def align_pads_action(self):
         """


### PR DESCRIPTION
## Summary
- set `central_backup_dir` empty by default
- prompt for backup folder if missing
- allow configuring max backup files in backup properties
- removed the popup asking to load a .nod file when creating a project
- **remove list selected pads feature and fix malformed constants file**

## Testing
- `ruff format ui/board_view/board_view.py ui/board_view/shortcuts.py edit_pads/actions.py`
- `black ui/board_view/board_view.py ui/board_view/shortcuts.py edit_pads/actions.py project_manager/project_manager.py ui/main_menu.py --fast`
- `ruff check project_manager/project_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856b07db79c832cbf8b4a8e698e6800