### PR TITLE
Fix pad numbering prompts

### DIFF
--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -309,16 +309,18 @@ class ComponentPlacer(QObject):
             return pos_x, pos_y, final_angle
 
         def calc_new_pin(original_pin):
+            if merge_choice is None:
+                return original_pin
+            nonlocal merge_counter
             if merge_choice:
                 if missing_pins:
                     return missing_pins.pop(0)
-                else:
-                    nonlocal merge_counter
-                    new_val = highest_pin + merge_counter
-                    merge_counter += 1
-                    return new_val
-            else:
-                return original_pin + highest_pin
+                new_val = highest_pin + merge_counter
+                merge_counter += 1
+                return new_val
+            new_val = highest_pin + merge_counter
+            merge_counter += 1
+            return new_val
 
         def get_alf_mapping(comp_base, comp_dir):
             alf_path = (
@@ -745,14 +747,16 @@ class ComponentPlacer(QObject):
         def calc_new_pin(original_pin: int) -> int:
             if merge_choice is None:
                 return original_pin
+            nonlocal merge_counter
             if merge_choice:
                 if missing_pins:
                     return missing_pins.pop(0)
-                nonlocal merge_counter
                 new_val = highest_pin + merge_counter
                 merge_counter += 1
                 return new_val
-            return original_pin + highest_pin
+            new_val = highest_pin + merge_counter
+            merge_counter += 1
+            return new_val
 
         # ------------------------------------------------------------------
         # 2)  Build BoardObject list

--- a/edit_pads/actions.py
+++ b/edit_pads/actions.py
@@ -166,11 +166,12 @@ def copy_pads(object_library, pad_items):
     if len(numeric_pins) > 1:
         numbers_sorted = sorted(numeric_pins)
         gaps = any(b - a != 1 for a, b in zip(numbers_sorted, numbers_sorted[1:]))
-        if gaps:
+        starts_at_one = numbers_sorted[0] == 1
+        if gaps or not starts_at_one:
             reply = QMessageBox.question(
                 None,
                 "Copy Pads",
-                "Gaps detected in pin numbers. Preserve numbering?",
+                "Gaps detected or numbering doesn't start at 1. Preserve numbering?",
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.Yes,
             )


### PR DESCRIPTION
## Summary
- handle pad sequences that don't start at pin 1 when copying pads
- renumber pads sequentially when appending/filling regardless of original numbering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf78b1c4c832cb78a59ed1950e84a