### PR TITLE
Fix BOM duplicate names

### DIFF
--- a/component_placer/bom_handler/bom_handler.py
+++ b/component_placer/bom_handler/bom_handler.py
@@ -410,3 +410,37 @@ class BOMHandler:
                     module="BOMHandler", func="import_from_mismatch_xlsx")
         self.log.debug(f"New BOM state: {self.bom}", module="BOMHandler", func="import_from_mismatch_xlsx")
         return True
+
+    def fix_duplicate_names(self, object_library=None):
+        """Ensure component names are unique (case-insensitive).
+
+        If duplicates are found, later occurrences are renamed with a trailing
+        ``_A``. Renamed board objects in ``object_library`` are also updated.
+
+        Returns a list of tuples ``(old_name, new_name)`` for any renames made.
+        """
+        seen = {}
+        renames = []
+        for name in list(self.bom.keys()):
+            key = name.lower()
+            if key in seen:
+                new_name = name + "_A"
+                existing_lower = {n.lower() for n in self.bom.keys()}
+                while new_name.lower() in existing_lower:
+                    new_name += "A"
+                self.bom[new_name] = self.bom.pop(name)
+                renames.append((name, new_name))
+                if object_library:
+                    for obj in object_library.get_all_objects():
+                        if obj.component_name.lower() == name.lower():
+                            obj.component_name = new_name
+                seen[new_name.lower()] = new_name
+            else:
+                seen[key] = name
+        if renames:
+            self.log.warning(
+                f"Duplicate component names fixed: {renames}",
+                module="BOMHandler",
+                func="fix_duplicate_names",
+            )
+        return renames

--- a/project_manager/project_manager.py
+++ b/project_manager/project_manager.py
@@ -453,6 +453,27 @@ class ProjectManager(QObject):
 
             self.log.log("info", "Skipping image check; images already up‑to‑date.")
 
+            # --- ensure unique component names ---
+            renames = self.bom_handler.fix_duplicate_names(self.object_library)
+            if renames:
+                rename_msg = "\n".join([f"{old} -> {new}" for old, new in renames])
+                QMessageBox.warning(
+                    self.main_window,
+                    "Duplicate Names Fixed",
+                    "Duplicate component names were detected and renamed:\n" + rename_msg,
+                )
+                board_set = set(
+                    [obj.component_name for obj in self.object_library.get_all_objects()]
+                )
+                from component_placer.bom_handler.bom_editor_dialog import BOMEditorDialog
+                dlg = BOMEditorDialog(
+                    bom_handler=self.bom_handler,
+                    board_component_names=board_set,
+                    parent=self.main_window,
+                )
+                if dlg.exec_() != dlg.Accepted:
+                    return
+
             # NOD ----------------------------------------------------------------
             t0 = time.perf_counter()
             nod_file = BoardNodFile(nod_path, object_library=self.object_library)
@@ -586,6 +607,27 @@ class ProjectManager(QObject):
         bom_path = os.path.join(new_proj_dir, "project_bom.csv")
 
         self.log.log("info", f"Saving project to new folder: {new_proj_dir}")
+
+        # --- ensure unique component names ---
+        renames = self.bom_handler.fix_duplicate_names(self.object_library)
+        if renames:
+            rename_msg = "\n".join([f"{old} -> {new}" for old, new in renames])
+            QMessageBox.warning(
+                self.main_window,
+                "Duplicate Names Fixed",
+                "Duplicate component names were detected and renamed:\n" + rename_msg,
+            )
+            board_set = set(
+                [obj.component_name for obj in self.object_library.get_all_objects()]
+            )
+            from component_placer.bom_handler.bom_editor_dialog import BOMEditorDialog
+            dlg = BOMEditorDialog(
+                bom_handler=self.bom_handler,
+                board_component_names=board_set,
+                parent=self.main_window,
+            )
+            if dlg.exec_() != dlg.Accepted:
+                return
 
         # ── 5. save images (same as before) ───────────────────────
         self.image_handler.save_image(top_image_path, "top")


### PR DESCRIPTION
## Summary
- prevent duplicate names in BOM editor
- ensure unique BOM names when saving projects
- automatically rename duplicate BOM entries with `_A`
- check duplicates on `Save As` and launch BOM editor for approval

## Testing
- `pytest -q`
- `python -m py_compile component_placer/bom_handler/bom_editor_dialog.py component_placer/bom_handler/bom_handler.py project_manager/project_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68762b7b4998832cbdd12eee35370189