### PR TITLE
Enable correct pad angle handling

### DIFF
--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -305,8 +305,15 @@ class ComponentPlacer(QObject):
             pos_x = x_mm + rx
             pos_y = y_mm + ry
 
-            final_angle = (pad.get("angle_deg", 0.0) + self.footprint_rotation) % 360
-            return pos_x, pos_y, final_angle
+            base_angle = (pad.get("angle_deg", 0.0) + self.footprint_rotation) % 360
+
+            if self.is_flipped:
+                base_angle = (180 - base_angle) % 360
+
+            if side == "bottom":
+                base_angle = (180 - base_angle) % 360
+
+            return pos_x, pos_y, base_angle
 
         def calc_new_pin(original_pin):
             if merge_choice is None:
@@ -559,9 +566,7 @@ class ComponentPlacer(QObject):
         # Prepare a message for the user.
         msg = f"Component '{comp_name}' already exists with pins: {sorted(existing_pins)}.\n"
         if missing:
-            msg += (
-                f"Missing pins: {missing}.\nDo you want to fill these gaps with new pads?"
-            )
+            msg += f"Missing pins: {missing}.\nDo you want to fill these gaps with new pads?"
         else:
             msg += (
                 "No gaps found. Do you want to append new pads at the end?\n"

--- a/constants/constants.txt
+++ b/constants/constants.txt
@@ -26,6 +26,7 @@
     "central_backup_dir": "",
     "max_backups": 5,
     "anchor_nudge_step_mm": 0.2,
+    "ghost_rotation_step_deg": 15,
     "max_zoom": 10.0,
     "quick_prefix_table": [
         "A",
@@ -55,6 +56,6 @@
         "AE",
         "AF",
         "AG",
-        "AH"
-    ]
+        "AH",
+    ],
 }

--- a/display/display_library.py
+++ b/display/display_library.py
@@ -1,14 +1,12 @@
 # display/display_library.py
 
-import logging
 from typing import List
-from PyQt5.QtCore import Qt, QRectF, QObject
+from PyQt5.QtCore import Qt, QObject
 from PyQt5.QtGui import QColor, QPen, QBrush, QPainterPath
-from PyQt5.QtWidgets import QGraphicsObject, QGraphicsItemGroup, QGraphicsScene
+from PyQt5.QtWidgets import QGraphicsObject, QGraphicsItemGroup
 from objects.board_object import BoardObject
 from logs.log_handler import LogHandler
 from constants.constants import Constants
-from display.coord_converter import CoordinateConverter
 from utils.flag_manager import FlagManager
 from display.pad_shapes import build_pad_path  # Helper to create QPainterPath for a pad
 
@@ -17,6 +15,7 @@ class SelectablePadItem(QGraphicsObject):
     """
     A custom QGraphicsObject that is selectable.
     """
+
     def __init__(self, path, board_object, log_handler, parent=None):
         super().__init__(parent)
         self.path = path
@@ -25,8 +24,7 @@ class SelectablePadItem(QGraphicsObject):
 
         # Make it selectable (and focusable if desired).
         self.setFlags(
-            QGraphicsObject.ItemIsSelectable
-            | QGraphicsObject.ItemIsFocusable
+            QGraphicsObject.ItemIsSelectable | QGraphicsObject.ItemIsFocusable
         )
 
         # Accept hover, touch, and all mouse buttons
@@ -123,7 +121,7 @@ class DisplayLibrary(QObject):
             "info",
             f"DisplayLibrary initialized for side '{self.current_side}'. Starting render with 0 objects.",
             module="DisplayLibrary",
-            func="__init__"
+            func="__init__",
         )
 
         # Render everything initially
@@ -141,7 +139,7 @@ class DisplayLibrary(QObject):
             "info",
             f"Rendering initial objects: found {len(all_objects)} in library.",
             module="DisplayLibrary",
-            func="render_initial_objects"
+            func="render_initial_objects",
         )
         rendered_count = 0
         for obj in all_objects:
@@ -152,7 +150,7 @@ class DisplayLibrary(QObject):
             f"Rendered {rendered_count} object(s) for side '{self.current_side}'. "
             f"Display now has {len(self.displayed_objects)} objects.",
             module="DisplayLibrary",
-            func="render_initial_objects"
+            func="render_initial_objects",
         )
 
     # --------------------------------------------------------------------------
@@ -168,14 +166,14 @@ class DisplayLibrary(QObject):
             "info",
             f"Object added: '{board_obj.component_name}' (ch {board_obj.channel}). Now rendering...",
             module="DisplayLibrary",
-            func="on_object_added"
+            func="on_object_added",
         )
         self.render_object(board_obj)
         self.log.log(
             "info",
             f"Display now has {len(self.displayed_objects)} objects after addition.",
             module="DisplayLibrary",
-            func="on_object_added"
+            func="on_object_added",
         )
 
     def on_object_removed(self, board_obj: BoardObject):
@@ -187,14 +185,14 @@ class DisplayLibrary(QObject):
             "info",
             f"Removing object '{board_obj.component_name}' (ch {board_obj.channel}).",
             module="DisplayLibrary",
-            func="on_object_removed"
+            func="on_object_removed",
         )
         self.remove_rendered_object(board_obj.channel)
         self.log.log(
             "info",
             f"Display now has {len(self.displayed_objects)} objects after removal.",
             module="DisplayLibrary",
-            func="on_object_removed"
+            func="on_object_removed",
         )
 
     def on_object_updated(self, board_obj: BoardObject):
@@ -206,7 +204,7 @@ class DisplayLibrary(QObject):
             "info",
             f"Updating object '{board_obj.component_name}' (ch {board_obj.channel}).",
             module="DisplayLibrary",
-            func="on_object_updated"
+            func="on_object_updated",
         )
         self.remove_rendered_object(board_obj.channel)
         self.render_object(board_obj)
@@ -214,7 +212,7 @@ class DisplayLibrary(QObject):
             "info",
             f"Display now has {len(self.displayed_objects)} objects after update.",
             module="DisplayLibrary",
-            func="on_object_updated"
+            func="on_object_updated",
         )
 
     # --------------------------------------------------------------------------
@@ -234,12 +232,12 @@ class DisplayLibrary(QObject):
                 "debug",
                 f"Skipping render: Channel {board_obj.channel} => visible=False.",
                 module="DisplayLibrary",
-                func="render_object"
+                func="render_object",
             )
             return False
 
         tp = board_obj.test_position.lower()  # e.g. 'top', 'bottom', or 'both'
-        tech = board_obj.technology.lower()   # e.g. 'smd', 'through hole'
+        tech = board_obj.technology.lower()  # e.g. 'smd', 'through hole'
         current = self.current_side
         created_anything = False
 
@@ -259,7 +257,7 @@ class DisplayLibrary(QObject):
                     "warning",
                     f"Failed to create primary pad item for channel={board_obj.channel}.",
                     module="DisplayLibrary",
-                    func="render_object"
+                    func="render_object",
                 )
 
         # 2) Secondary pad for through-hole if on opposite side
@@ -277,12 +275,16 @@ class DisplayLibrary(QObject):
 
         return created_anything
 
-    def create_pad_item(self, pad: BoardObject, pen: QPen, brush: QBrush) -> QGraphicsObject:
+    def create_pad_item(
+        self, pad: BoardObject, pen: QPen, brush: QBrush
+    ) -> QGraphicsObject:
         """
         Builds the QPainterPath for the pad, then creates a SelectablePadItem,
         positions it, and returns it. Returns None if build_pad_path fails.
         """
-        path = self._build_pad_path(pad.width_mm, pad.height_mm, pad.hole_mm, pad.shape_type)
+        path = self._build_pad_path(
+            pad.width_mm, pad.height_mm, pad.hole_mm, pad.shape_type
+        )
         if not path:
             return None
 
@@ -291,8 +293,12 @@ class DisplayLibrary(QObject):
         item.setPen(pen)
         item.setBrush(brush)
         item.setPos(x_scene, y_scene)
+
+        angle = pad.angle_deg
+        if self.current_side == "bottom":
+            angle = (180 - angle) % 360
         # Rotate counter-clockwise for positive angles
-        item.setRotation(-pad.angle_deg)
+        item.setRotation(-angle)
         item.setZValue(self.z_value_pads)
         return item
 
@@ -306,13 +312,7 @@ class DisplayLibrary(QObject):
         else:
             mm_per_pixel = self.converter.mm_per_pixels_bot
 
-        return build_pad_path(
-            width_mm,
-            height_mm,
-            hole_mm,
-            shape_type,
-            mm_per_pixel
-        )
+        return build_pad_path(width_mm, height_mm, hole_mm, shape_type, mm_per_pixel)
 
     # --------------------------------------------------------------------------
     #  REMOVING / CLEARING
@@ -340,7 +340,12 @@ class DisplayLibrary(QObject):
             self.group.removeFromGroup(itm)
             self.scene.removeItem(itm)
         self.displayed_objects.clear()
-        self.log.log("info", "All rendered objects cleared.", module="DisplayLibrary", func="clear_all_rendered_objects")
+        self.log.log(
+            "info",
+            "All rendered objects cleared.",
+            module="DisplayLibrary",
+            func="clear_all_rendered_objects",
+        )
 
     # --------------------------------------------------------------------------
     #  PARTIAL UPDATE METHODS (for bulk operations)
@@ -382,7 +387,7 @@ class DisplayLibrary(QObject):
             "info",
             f"Side changed to '{self.current_side}'. Re-rendering display...",
             module="DisplayLibrary",
-            func="update_display_side"
+            func="update_display_side",
         )
         self.clear_all_rendered_objects()
         self.render_initial_objects()
@@ -392,18 +397,13 @@ class DisplayLibrary(QObject):
     # --------------------------------------------------------------------------
     def get_pad_color(self, testability_code: str) -> QColor:
         color_mapping = {
-            'F': QColor(0xC0, 0x60, 0xC0),  # Forced  (magenta-ish)
-            'T': QColor(0x00, 0x64, 0x00),  # Testable (dark green)
-            'N': QColor(0x60, 0x60, 0x60),  # Not testable (grey)
-            'E': QColor(0x80, 0x80, 0x00)   # Terminal (olive)
+            "F": QColor(0xC0, 0x60, 0xC0),  # Forced  (magenta-ish)
+            "T": QColor(0x00, 0x64, 0x00),  # Testable (dark green)
+            "N": QColor(0x60, 0x60, 0x60),  # Not testable (grey)
+            "E": QColor(0x80, 0x80, 0x00),  # Terminal (olive)
         }
         return color_mapping.get(testability_code, QColor(0, 0, 0))
 
     def testability_to_code(self, testability_str: str) -> str:
-        mapping = {
-            "Forced": "F",
-            "Testable": "T",
-            "Not Testable": "N",
-            "Terminal": "E"
-        }
+        mapping = {"Forced": "F", "Testable": "T", "Not Testable": "N", "Terminal": "E"}
         return mapping.get(testability_str, "N")

--- a/edit_pads/actions.py
+++ b/edit_pads/actions.py
@@ -73,12 +73,14 @@ def _extract_pad_data(pad, current_side, board_view):
     angle = obj.angle_deg
 
     # If side is "bottom", flip x by the board's physical width in mm
+    # and convert the stored angle back to the visual orientation
     if current_side == "bottom":
         # The bottom scale factor for width
         mm_per_pixel = board_view.converter.mm_per_pixels_bot
         # The board's pixel width * mm_per_pixel => total width in mm
         board_width_mm = board_view.converter.image_width * mm_per_pixel
         x_mm = board_width_mm - x_mm
+        angle = (180 - angle) % 360
 
     # Build a data dict describing this pad
     pad_data = {

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -468,6 +468,10 @@ class MainWindow(QMainWindow):
         set_max_zoom_action.triggered.connect(self.set_max_zoom)
         controls_menu.addAction(set_max_zoom_action)
 
+        set_rotation_step_action = QAction("Set Ghost Rotation Step", self)
+        set_rotation_step_action.triggered.connect(self.set_ghost_rotation_step)
+        controls_menu.addAction(set_rotation_step_action)
+
         # ----- Prefix submenu -----
         prefix_menu = properties_menu.addMenu("Prefix")
         set_prefix_table_action = QAction("Set Quick Prefix Table", self)
@@ -1188,6 +1192,22 @@ class MainWindow(QMainWindow):
                 self.board_view.zoom_manager.max_user_scale = value
                 self.board_view.zoom_manager.update_zoom_limits()
             self.log.log("debug", f"Max zoom updated to {value}")
+
+    def set_ghost_rotation_step(self):
+        """Prompt user for new ghost rotation step in degrees."""
+        current_value = int(self.constants.get("ghost_rotation_step_deg", 15))
+        value, ok = QInputDialog.getInt(
+            self,
+            "Ghost Rotation Step",
+            "Enter rotation step (degrees):",
+            value=current_value,
+            min=1,
+            max=360,
+        )
+        if ok:
+            self.constants.set("ghost_rotation_step_deg", value)
+            self.constants.save()
+            self.log.log("debug", f"Ghost rotation step updated to {value} degrees")
 
     def set_quick_prefix_table(self):
         """Prompt user to edit the comma-separated quick prefix table."""


### PR DESCRIPTION
## Summary
- flip pad angle when placing on the bottom side so it matches the ghost
- adjust rendering to rotate bottom-side pads using the flipped angle
- show pad angle in the pad editor table and export
- correct bottom-side angle when copying pads

## Testing
- `ruff check edit_pads/actions.py`
- `black --check edit_pads/actions.py`
- `pre-commit run --files edit_pads/actions.py` *(fails: error: pathspec 'v3.2.4' did not match any file)*

------
https://chatgpt.com/codex/tasks/task_e_687c993a4f58832cbaf041e686ce4159