### PR TITLE
Add help dialog showing README

### DIFF
--- a/ui/help_dialog.py
+++ b/ui/help_dialog.py
@@ -1,0 +1,34 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QTextBrowser, QPushButton
+import os
+
+
+class HelpDialog(QDialog):
+    """Simple dialog to display the project README as help text."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("User Guide")
+        layout = QVBoxLayout(self)
+        self.text_browser = QTextBrowser()
+        self.text_browser.setOpenExternalLinks(True)
+        layout.addWidget(self.text_browser)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.accept)
+        layout.addWidget(close_btn)
+
+    def load_help_content(self, path: str):
+        """Load markdown or plain text from `path` into the text browser."""
+        if not os.path.isfile(path):
+            self.text_browser.setPlainText(f"Help file not found: {path}")
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read()
+            # QTextBrowser can render basic Markdown via setMarkdown
+            try:
+                self.text_browser.setMarkdown(content)
+            except Exception:
+                # Fallback to plain text
+                self.text_browser.setPlainText(content)
+        except Exception as exc:
+            self.text_browser.setPlainText(f"Failed to load help file: {exc}")

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -478,6 +478,12 @@ class MainWindow(QMainWindow):
         set_prefix_table_action.triggered.connect(self.set_quick_prefix_table)
         prefix_menu.addAction(set_prefix_table_action)
 
+        # ------------------- HELP Menu ------------------
+        help_menu = menubar.addMenu("Help")
+        help_action = QAction("User Guide", self)
+        help_action.triggered.connect(self.open_help_dialog)
+        help_menu.addAction(help_action)
+
     # ------------------------------------------------------------------
     #  Board Origin Setter
     # ------------------------------------------------------------------
@@ -1267,3 +1273,15 @@ class MainWindow(QMainWindow):
         # pad text to constant width (5 chars = 'Top  ' / 'Bottom')
         txt = f"Side: {current_side:<6}"
         self.working_side_label.setText(txt)
+
+    def open_help_dialog(self):
+        """Open a simple dialog displaying the README as a user guide."""
+        from ui.help_dialog import HelpDialog
+
+        dlg = HelpDialog(self)
+        # Locate README relative to the project root
+        root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        readme_path = os.path.join(root_dir, "README.md")
+        dlg.load_help_content(readme_path)
+        dlg.resize(700, 600)
+        dlg.exec_()


### PR DESCRIPTION
## Summary
- add simple HelpDialog with markdown viewer
- show new Help menu with link to User Guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cd443b048832cbeec809bb5b0331d