### PR TITLE
Add pad connect action

### DIFF
--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -463,6 +463,7 @@ class ComponentPlacer(QObject):
                     component_name=comp_name,
                     pin=new_pin_str,
                     channel=None,
+                    signal=pad.get("signal"),
                     test_position=side,
                     testability=pad.get("testability", "Not Testable"),
                     x_coord_mm=pos_x,
@@ -778,6 +779,7 @@ class ComponentPlacer(QObject):
             obj = BoardObject(
                 component_name=comp_name,
                 pin=str(new_pin),
+                signal=pad.get("signal"),
                 x_coord_mm=pad["x_coord_mm"],
                 y_coord_mm=pad["y_coord_mm"],
                 width_mm=pad["width_mm"],

--- a/objects/board_object.py
+++ b/objects/board_object.py
@@ -8,6 +8,7 @@ class BoardObject:
         component_name: str,
         pin: int,
         channel: Optional[int] = None,
+        signal: Optional[str] = None,
         test_position: str = "Top",
         testability: str = "Not Testable",
         x_coord_mm: float = 0.0,
@@ -23,6 +24,7 @@ class BoardObject:
         self.component_name = component_name
         self.pin = pin
         self.channel = channel
+        self.signal = signal or (f"S{channel}" if channel is not None else "S0")
         self.test_position = test_position
         self.testability = testability
 
@@ -50,10 +52,6 @@ class BoardObject:
         # New attribute to control visibility (default is True)
         self.visible = True
 
-    @property
-    def signal(self) -> str:
-        return f"S{self.channel}" if self.channel is not None else "S0"
-
     def update_coordinates(self, x_mm: float, y_mm: float):
         self.x_coord_mm = x_mm
         self.y_coord_mm = y_mm
@@ -63,6 +61,7 @@ class BoardObject:
             "component_name": self.component_name,
             "pin": self.pin,
             "channel": self.channel,
+            "signal": self.signal,
             "test_position": self.test_position,
             "testability": self.testability,
             "x_coord_mm": self.x_coord_mm,

--- a/objects/nod_file.py
+++ b/objects/nod_file.py
@@ -490,6 +490,7 @@ class BoardNodFile:
                 component_name=pad["component_name"],
                 pin=pad["pin"],
                 channel=pad["channel"],
+                signal=pad.get("signal"),
                 x_coord_mm=pad["x_coord_mm"],
                 y_coord_mm=pad["y_coord_mm"],
                 shape_type=pad["shape_type"],

--- a/ui/board_view/board_view.py
+++ b/ui/board_view/board_view.py
@@ -517,6 +517,7 @@ class BoardView(QGraphicsView):
         edit_action = QAction("Edit", self)
         cut_action = QAction("Cut", self)
         move_action = QAction("Move", self)
+        connect_action = QAction("Connect", self)
 
         copy_action.triggered.connect(
             lambda: actions.copy_pads(self.object_library, selected_pads)
@@ -538,6 +539,9 @@ class BoardView(QGraphicsView):
                 self.object_library, selected_pads, self.component_placer
             )
         )
+        connect_action.triggered.connect(
+            lambda: actions.connect_pads(self.object_library, selected_pads)
+        )
 
         # NEW: "Export Footprint"
         export_footprint_action = QAction("Export Footprint", self)
@@ -550,6 +554,7 @@ class BoardView(QGraphicsView):
         menu.addAction(cut_action)
         menu.addAction(paste_action)
         menu.addAction(move_action)
+        menu.addAction(connect_action)
         menu.addAction(delete_action)
         menu.addAction(edit_action)
         menu.addSeparator()
@@ -771,6 +776,17 @@ class BoardView(QGraphicsView):
             actions.move_pads(self.object_library, selected, self.component_placer)
         except Exception as e:
             self.log.log("error", f"Error in move_selected_pads: {e}")
+
+    def connect_selected_pads(self):
+        """Connects multiple pads to share one signal."""
+        selected = self._get_selected_pads()
+        if not selected:
+            self.log.log("warning", "No pads selected to connect.")
+            return
+        try:
+            actions.connect_pads(self.object_library, selected)
+        except Exception as e:
+            self.log.log("error", f"Error in connect_selected_pads: {e}")
 
     def open_pad_editor_dialog(self, pad_items):
         """

--- a/ui/board_view/shortcuts.py
+++ b/ui/board_view/shortcuts.py
@@ -58,6 +58,10 @@ def setup_board_view_shortcuts(board_view):
     board_view.move_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
     board_view.move_shortcut.activated.connect(board_view.move_selected_pads)
 
+    board_view.connect_shortcut = QShortcut(QKeySequence("Ctrl+Q"), board_view)
+    board_view.connect_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
+    board_view.connect_shortcut.activated.connect(board_view.connect_selected_pads)
+
     #  Flip ghost horizontally  (Ctrl+H)
     board_view.flip_shortcut = QShortcut(QKeySequence("Ctrl+H"), board_view)
     board_view.flip_shortcut.setContext(Qt.WidgetWithChildrenShortcut)


### PR DESCRIPTION
## Summary
- allow pads to store explicit signal names
- add action to connect pads to a single signal and mark additional pads as terminal
- expose "Connect" option in board view context menu and add Ctrl+Q shortcut

## Testing
- `pre-commit run --files ui/board_view/shortcuts.py` *(fails: error: pathspec 'v3.2.4' did not match any file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f069245b8832c885ca0e841b6d8c0