### PR TITLE
Select forced pad with largest area

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.2.4
+    rev: v3.1.0
     hooks:
       - id: prettier

--- a/edit_pads/actions.py
+++ b/edit_pads/actions.py
@@ -1,19 +1,13 @@
-import logging
 from PyQt5.QtWidgets import QMessageBox, QInputDialog
 from PyQt5.QtCore import Qt, QTimer
 from logs.log_handler import LogHandler
 from edit_pads.pad_editor_dialog import PadEditorDialog
-from objects.board_object import BoardObject
-from objects.nod_file import BoardNodFile
-from component_placer.component_placer import clipboard, ComponentPlacer
-from component_placer.ghost import GhostComponent
+from component_placer.component_placer import clipboard
 from statistics import mean
 import copy
 
 # Initialize a logger
 log = LogHandler(output="both")
-
-from PyQt5.QtWidgets import QMessageBox
 
 
 # --------------------
@@ -353,8 +347,6 @@ def edit_pads(object_library, pad_items):
     # This ensures we have the correct QGraphicsView instance to refresh the scene.
     board_view = valid_pad_items[0].scene().views()[0] if valid_pad_items else None
 
-    from edit_pads.pad_editor_dialog import PadEditorDialog
-
     dialog = PadEditorDialog(
         selected_pads=board_objects,
         object_library=object_library,
@@ -433,14 +425,6 @@ def move_pads(object_library, pad_items, component_placer):
         QMessageBox.warning(None, "Move Pads", "No valid pad data available.")
         return
 
-    xs = [pad["x_coord_mm"] for pad in pads_data]
-    ys = [pad["y_coord_mm"] for pad in pads_data]
-    footprint = {
-        "pads": pads_data,
-        "center_x": (min(xs) + max(xs)) / 2.0,
-        "center_y": (min(ys) + max(ys)) / 2.0,
-    }
-
     if component_placer.ghost_component is None:
         from component_placer.ghost import GhostComponent
 
@@ -458,9 +442,9 @@ def connect_pads(object_library, pad_items):
     """Connects multiple selected pads to share the same signal.
 
     The user chooses one of the existing signal names from the selection. All
-    pads are updated to use that signal. Exactly one pad remains with
-    ``testability == "Forced"`` (the first pad already forced or, if none,
-    the first pad in the selection) and the rest become ``"Terminal"``.
+    pads are updated to use that signal. The pad with the largest area
+    (``width_mm * height_mm``) becomes ``testability == "Forced"`` and the
+    rest are set to ``"Terminal"``.
     """
     if not _ensure_selection("Connect Pads", pad_items):
         return
@@ -488,14 +472,11 @@ def connect_pads(object_library, pad_items):
         if not ok:
             return
 
-    # Determine which pad remains forced
-    forced_obj = None
-    for pad in valid_pad_items:
-        if pad.board_object.testability == "Forced":
-            forced_obj = pad.board_object
-            break
-    if forced_obj is None:
-        forced_obj = valid_pad_items[0].board_object
+    # Determine which pad remains forced based on largest area
+    forced_obj = max(
+        (pad.board_object for pad in valid_pad_items),
+        key=lambda obj: obj.width_mm * obj.height_mm,
+    )
 
     updates = []
     for pad in valid_pad_items:
@@ -510,6 +491,7 @@ def connect_pads(object_library, pad_items):
 
     object_library.bulk_update_objects(updates, {})
     _update_scene(valid_pad_items[0].scene().views()[0])
+
 
 def align_selected_pads(object_library, selected_pads, component_placer):
     """

--- a/tests/test_connect_pads.py
+++ b/tests/test_connect_pads.py
@@ -1,0 +1,83 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import edit_pads.actions as actions  # noqa: E402
+from objects.board_object import BoardObject  # noqa: E402
+
+
+class FakeObjectLibrary:
+    def __init__(self):
+        self.updated = None
+
+    def bulk_update_objects(self, updates, _):
+        self.updated = updates
+
+
+class FakeBoardView:
+    pass
+
+
+class FakeScene:
+    def __init__(self):
+        self._views = [FakeBoardView()]
+
+    def views(self):
+        return self._views
+
+
+class FakePadItem:
+    def __init__(self, board_object):
+        self.board_object = board_object
+        self._scene = FakeScene()
+
+    def scene(self):
+        return self._scene
+
+
+def test_connect_pads_forces_largest_area(monkeypatch):
+    obj_lib = FakeObjectLibrary()
+    pad1 = FakePadItem(
+        BoardObject(
+            "C1",
+            1,
+            channel=1,
+            signal="SIG",
+            width_mm=1,
+            height_mm=1,
+            testability="Terminal",
+        )
+    )
+    pad2 = FakePadItem(
+        BoardObject(
+            "C1",
+            2,
+            channel=2,
+            signal="SIG",
+            width_mm=2,
+            height_mm=2,
+            testability="Forced",
+        )
+    )
+    pad3 = FakePadItem(
+        BoardObject(
+            "C1",
+            3,
+            channel=3,
+            signal="SIG",
+            width_mm=3,
+            height_mm=3,
+            testability="Terminal",
+        )
+    )
+    pads = [pad1, pad2, pad3]
+    monkeypatch.setattr(actions, "_update_scene", lambda *args, **kwargs: None)
+
+    actions.connect_pads(obj_lib, pads)
+
+    forced = [o for o in obj_lib.updated if o.testability == "Forced"]
+    assert len(forced) == 1
+    assert forced[0].width_mm == 3 and forced[0].height_mm == 3
+
+    non_forced = [o for o in obj_lib.updated if o is not forced[0]]
+    assert all(o.testability == "Terminal" for o in non_forced)


### PR DESCRIPTION
## Summary
- Ensure `connect_pads` forces the pad with the largest area and mark others as terminals
- Fix pre-commit config to use an available Prettier version
- Add a unit test for largest-area pad selection

## Testing
- `pre-commit run --files edit_pads/actions.py tests/test_connect_pads.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f40fdbf94832c99f041f683814711