### PR TITLE
Normalize pad signals and improve BOM mismatch dialog

### DIFF
--- a/component_placer/component_placer.py
+++ b/component_placer/component_placer.py
@@ -645,19 +645,26 @@ class ComponentPlacer(QObject):
             old = existing.get(field, "")
             new = new_data.get(field, "")
             if old != new:
-                diffs.append(f"{field}: BOM='{old}' | Input='{new}'")
+                diffs.append((field, old, new))
 
         if not diffs:
             # No differences detected; nothing to update.
             return False
 
+        # Build an HTML table to present the differences more clearly.
+        rows = "".join(
+            f"<tr><td><b>{field}</b></td><td>{old}</td><td>{new}</td></tr>"
+            for field, old, new in diffs
+        )
         msg = (
-            f"Component '{comp_name}' exists in BOM with different data:\n"
-            + "\n".join(diffs)
-            + "\nUpdate BOM with new values?"
+            f"Component '{comp_name}' exists in BOM with different data:<br><br>"
+            "<table border='1' cellspacing='0' cellpadding='3'>"
+            "<tr><th>Field</th><th>BOM</th><th>Input</th></tr>"
+            f"{rows}</table><br>Update BOM with new values?"
         )
         msg_box = QMessageBox()
         msg_box.setWindowTitle("BOM Mismatch")
+        msg_box.setTextFormat(Qt.RichText)
         msg_box.setText(msg)
         update_btn = msg_box.addButton("Update BOM", QMessageBox.AcceptRole)
         keep_btn = msg_box.addButton("Keep Existing", QMessageBox.RejectRole)

--- a/objects/object_library.py
+++ b/objects/object_library.py
@@ -99,6 +99,16 @@ class ObjectLibrary(QObject):
                 )
                 board_object.channel = assigned_channel
 
+            # Ensure the signal name matches the assigned channel if the
+            # incoming signal is missing or a library placeholder (e.g.
+            # '$FOFE$_t7/1').
+            if (
+                not board_object.signal
+                or board_object.signal == "S0"
+                or str(board_object.signal).startswith("$")
+            ):
+                board_object.signal = f"S{board_object.channel}"
+
             # Store the object
             self.objects[board_object.channel] = board_object
 
@@ -184,6 +194,14 @@ class ObjectLibrary(QObject):
                 # assign a free channel if needed
                 if (obj.channel is None) or (obj.channel in self.objects):
                     obj.channel = self.get_next_channel()
+
+                # Normalize placeholder signals (missing or library defaults)
+                if (
+                    not obj.signal
+                    or obj.signal == "S0"
+                    or str(obj.signal).startswith("$")
+                ):
+                    obj.signal = f"S{obj.channel}"
 
                 self.objects[obj.channel] = obj
                 added_objects.append(obj)

--- a/tests/test_signal_assignment.py
+++ b/tests/test_signal_assignment.py
@@ -1,0 +1,32 @@
+from objects.board_object import BoardObject
+from objects.object_library import ObjectLibrary
+
+
+def _reset_library() -> ObjectLibrary:
+    lib = ObjectLibrary()
+    # ObjectLibrary is a singleton; ensure a clean state for each test.
+    lib.objects.clear()
+    lib._next_channel_id = 1  # reset channel counter
+    return lib
+
+
+def test_bulk_add_replaces_library_signal():
+    lib = _reset_library()
+    obj = BoardObject(
+        component_name="C1", pin=1, signal="$FOFE$_t7/1", channel=None
+    )
+    lib.bulk_add([obj], skip_render=True)
+    assert obj.signal == "S1"
+    assert obj.channel == 1
+    lib.objects.clear()
+
+
+def test_bulk_add_preserves_existing_signal():
+    lib = _reset_library()
+    obj = BoardObject(
+        component_name="C1", pin=1, signal="SIG_CUSTOM", channel=None
+    )
+    lib.bulk_add([obj], skip_render=True)
+    assert obj.signal == "SIG_CUSTOM"
+    assert obj.channel == 1
+    lib.objects.clear()


### PR DESCRIPTION
## Summary
- Replace placeholder pad signals with channel-based names
- Render BOM mismatch details in an HTML table for clarity
- Test bulk_add signal normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920a213674832cb44fb769857c4dea