### PR TITLE
Ensure single forced pad per signal

### DIFF
--- a/tests/test_connect_pads.py
+++ b/tests/test_connect_pads.py
@@ -7,8 +7,11 @@ from objects.board_object import BoardObject  # noqa: E402
 
 
 class FakeObjectLibrary:
-    def __init__(self):
+    def __init__(self, objs=None):
         self.updated = None
+        self.objects = {}
+        if objs:
+            self.objects = {obj.channel: obj for obj in objs}
 
     def bulk_update_objects(self, updates, _):
         self.updated = updates
@@ -82,3 +85,68 @@ def test_connect_pads_forces_largest_area(monkeypatch):
 
     non_forced = [o for o in obj_lib.updated if o is not forced[0]]
     assert all(o.testability == "Terminal" for o in non_forced)
+
+
+def test_connect_pads_reduces_existing_forced(monkeypatch):
+    """Connecting pads to a signal with existing forced pads leaves only one forced."""
+    pad1 = FakePadItem(
+        BoardObject(
+            "C1",
+            1,
+            channel=1,
+            signal="S30",
+            width_mm=1,
+            height_mm=1,
+            testability="Forced",
+        )
+    )
+    pad2 = FakePadItem(
+        BoardObject(
+            "C1",
+            2,
+            channel=2,
+            signal="S30",
+            width_mm=1,
+            height_mm=1,
+            testability="Terminal",
+        )
+    )
+    pad3 = FakePadItem(
+        BoardObject(
+            "C1",
+            3,
+            channel=3,
+            signal="S31",
+            width_mm=3,
+            height_mm=3,
+            testability="Forced",
+        )
+    )
+    pad4 = FakePadItem(
+        BoardObject(
+            "C1",
+            4,
+            channel=4,
+            signal="S31",
+            width_mm=2,
+            height_mm=2,
+            testability="Terminal",
+        )
+    )
+
+    obj_lib = FakeObjectLibrary(
+        [pad1.board_object, pad2.board_object, pad3.board_object, pad4.board_object]
+    )
+
+    monkeypatch.setattr(actions, "_update_scene", lambda *args, **kwargs: None)
+
+    # Connect pad2 and pad4 so that all three pads with signal S31 are considered
+    actions.connect_pads(obj_lib, [pad2, pad4])
+
+    forced = [o for o in obj_lib.updated if o.testability == "Forced"]
+    assert len(forced) == 1
+    # Pad3 has the largest area among S31 pads
+    assert forced[0].channel == 3
+    terminals = [o for o in obj_lib.updated if o.testability == "Terminal"]
+    assert len(terminals) == 2
+    assert all(o.channel in (2, 4) for o in terminals)


### PR DESCRIPTION
## Summary
- Update pad connection logic to recompute forced vs terminal pads across entire signal group so only one pad remains forced
- Expand FakeObjectLibrary and add regression test to ensure merging pad groups preserves a single forced pad

## Testing
- `pytest tests/test_connect_pads.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68921137abc0832cbe91b6cbfbd07539