### PR TITLE
Add measurement tool for two-anchor distance checks

### DIFF
--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -43,6 +43,7 @@ import edit_pads.actions as actions
 from ui.layers_tab import LayersTab
 from component_placer.bom_handler.bom_handler import BOMHandler
 from component_placer.quick_creation_controller import QuickCreationController
+from ui.measure_tool import MeasureTool
 from ui.start_dialog import StartDialog
 
 
@@ -103,6 +104,15 @@ class MainWindow(QMainWindow):
             component_placer=self.component_placer,
             marker_manager=self.board_view.marker_manager,
             coord_converter=self.board_view.converter,
+        )
+
+        # ─── Measurement Tool ───────────────────────────────────────────
+        self.measure_tool = MeasureTool(
+            board_view=self.board_view,
+            input_handler=self.input_handler,
+            marker_manager=self.board_view.marker_manager,
+            coord_converter=self.board_view.converter,
+            pad_info_label=self.pad_info_label,
         )
 
         # ─── Link DisplayLibrary ─────────────────────────────────────────
@@ -248,6 +258,26 @@ class MainWindow(QMainWindow):
         if isinstance(btn_qc, QToolButton):
             btn_qc.setIconSize(LARGE)
             btn_qc.setFixedSize(LARGE)
+
+        # ── Measurement action (big icon) ───────────────────────────────
+        measure_action = QAction(
+            self.style().standardIcon(QStyle.SP_ArrowRight),
+            self.tr("Measure"),
+            self,
+        )
+        measure_action.setToolTip(self.tr("Activate measurement mode"))
+        measure_action.triggered.connect(
+            lambda: (
+                self.quick_creation_controller.deactivate(),
+                self.measure_tool.activate(),
+            )
+        )
+        tb.addAction(measure_action)
+
+        btn_meas = tb.widgetForAction(measure_action)
+        if isinstance(btn_meas, QToolButton):
+            btn_meas.setIconSize(LARGE)
+            btn_meas.setFixedSize(LARGE)
 
         # final stretch so items stay left-aligned
         tb.addSeparator()

--- a/ui/measure_tool.py
+++ b/ui/measure_tool.py
@@ -1,0 +1,184 @@
+from PyQt5.QtCore import QObject, QEvent, Qt
+from PyQt5.QtGui import QPen, QColor
+from PyQt5.QtWidgets import QGraphicsLineItem
+
+
+class MeasureTool(QObject):
+    """Simple two-anchor measurement tool.
+
+    When activated the user can place two anchors that define a right
+    triangle.  The tool draws three coloured lines (red = ΔX, blue = ΔY,
+    green = direct distance) and writes the measured distances to the
+    pad_info_label.  ESC exits the mode.
+    """
+
+    def __init__(
+        self, board_view, input_handler, marker_manager, coord_converter, pad_info_label
+    ):
+        super().__init__(board_view)
+        self.board_view = board_view
+        self.flags = board_view.flags
+        self.input_handler = input_handler
+        self.marker_manager = marker_manager
+        self.converter = coord_converter
+        self.pad_info_label = pad_info_label
+
+        self.active = False
+        self.state = 0  # 0=idle, 1=have A, 2=have A+B
+        self.anchors = {"A": None, "B": None}
+        self.lines = []
+
+        self.input_handler.mouse_clicked.connect(self._on_click)
+        self.board_view.installEventFilter(self)
+
+        # arrow key nudging similar to QuickCreation
+        self.input_handler.arrow_left.connect(
+            lambda: self._nudge_selected(self._flip_dx(-self._get_step()), 0.0)
+        )
+        self.input_handler.arrow_right.connect(
+            lambda: self._nudge_selected(self._flip_dx(self._get_step()), 0.0)
+        )
+        self.input_handler.arrow_up.connect(
+            lambda: self._nudge_selected(0.0, self._get_step())
+        )
+        self.input_handler.arrow_down.connect(
+            lambda: self._nudge_selected(0.0, -self._get_step())
+        )
+
+    # ------------------------------------------------------------------
+    def _flip_dx(self, dx: float) -> float:
+        return -dx if self.flags.get_flag("side", "top").lower() == "bottom" else dx
+
+    def _get_step(self) -> float:
+        try:
+            return float(
+                getattr(self.board_view, "constants", None).get(
+                    "anchor_nudge_step_mm", 0.2
+                )
+            )
+        except Exception:
+            return 0.2
+
+    # ------------------------------------------------------------------
+    def activate(self):
+        if self.active:
+            return
+        self.active = True
+        self.state = 0
+        self.anchors = {"A": None, "B": None}
+        self.marker_manager.clear_quick_anchors()
+        self._clear_lines()
+        self.board_view.setCursor(Qt.CrossCursor)
+        self.pad_info_label.setText(self.tr("Measurement: place first anchor"))
+
+    def deactivate(self):
+        if not self.active:
+            return
+        self.active = False
+        self.marker_manager.clear_quick_anchors()
+        self._clear_lines()
+        self.board_view.unsetCursor()
+        self.pad_info_label.setText(self.tr("No pad selected"))
+
+    # ------------------------------------------------------------------
+    def _clear_lines(self):
+        scene = self.board_view.scene
+        for ln in self.lines:
+            scene.removeItem(ln)
+        self.lines = []
+
+    # ------------------------------------------------------------------
+    def _on_click(self, x_scene: float, y_scene: float, button: str):
+        if not self.active or button != "left":
+            return
+        x_mm, y_mm = self.converter.pixels_to_mm(x_scene, y_scene)
+
+        if self.state == 0:
+            self.anchors["A"] = (x_mm, y_mm)
+            self.marker_manager.place_anchor("A", x_mm, y_mm)
+            self.state = 1
+            self.pad_info_label.setText(self.tr("Measurement: place second anchor"))
+            return
+
+        if self.state == 1:
+            self.anchors["B"] = (x_mm, y_mm)
+            self.marker_manager.place_anchor("B", x_mm, y_mm)
+            self.state = 2
+            self._draw_lines()
+            return
+
+        # start a new measurement on subsequent clicks
+        self.marker_manager.clear_quick_anchors()
+        self._clear_lines()
+        self.anchors = {"A": (x_mm, y_mm), "B": None}
+        self.marker_manager.place_anchor("A", x_mm, y_mm)
+        self.state = 1
+        self.pad_info_label.setText(self.tr("Measurement: place second anchor"))
+
+    # ------------------------------------------------------------------
+    def _draw_lines(self):
+        self._clear_lines()
+        A = self.anchors["A"]
+        B = self.anchors["B"]
+        if None in (A, B):
+            return
+
+        ax, ay = self.converter.mm_to_pixels(*A)
+        bx, by = self.converter.mm_to_pixels(*B)
+
+        pen_r = QPen(QColor("red"))
+        pen_b = QPen(QColor("blue"))
+        pen_g = QPen(QColor("green"))
+        for pen in (pen_r, pen_b, pen_g):
+            pen.setWidth(2)
+            pen.setCosmetic(True)
+
+        line_r = QGraphicsLineItem(ax, ay, bx, ay)
+        line_r.setPen(pen_r)
+        line_b = QGraphicsLineItem(bx, ay, bx, by)
+        line_b.setPen(pen_b)
+        line_g = QGraphicsLineItem(ax, ay, bx, by)
+        line_g.setPen(pen_g)
+
+        z = getattr(self.marker_manager, "z_value_marker", 2)
+        for ln in (line_r, line_b, line_g):
+            ln.setZValue(z)
+            self.board_view.scene.addItem(ln)
+
+        self.lines = [line_r, line_b, line_g]
+
+        dx = abs(B[0] - A[0])
+        dy = abs(B[1] - A[1])
+        dist = (dx**2 + dy**2) ** 0.5
+        self.pad_info_label.setText(
+            f"<span style='color:red'>ΔX: {dx:.2f} mm</span>&nbsp;&nbsp;"
+            f"<span style='color:blue'>ΔY: {dy:.2f} mm</span>&nbsp;&nbsp;"
+            f"<span style='color:green'>Dist: {dist:.2f} mm</span>"
+        )
+
+    # ------------------------------------------------------------------
+    def _nudge_selected(self, dx_mm: float, dy_mm: float):
+        if not self.active or self.state == 0:
+            return
+        selected_id = None
+        for aid, item in self.marker_manager.anchor_items.items():
+            if item.isSelected():
+                selected_id = aid
+                break
+        if not selected_id:
+            return
+        x, y = self.anchors[selected_id]
+        newx, newy = x + dx_mm, y + dy_mm
+        self.anchors[selected_id] = (newx, newy)
+        self.marker_manager.move_anchor(selected_id, newx, newy)
+        if self.state == 2:
+            self._draw_lines()
+
+    # ------------------------------------------------------------------
+    def eventFilter(self, obj, event):
+        if not self.active:
+            return super().eventFilter(obj, event)
+        if event.type() == QEvent.KeyPress and event.key() == Qt.Key_Escape:
+            self.deactivate()
+            return True
+        return super().eventFilter(obj, event)


### PR DESCRIPTION
## Summary
- introduce `MeasureTool` allowing two-anchor measurement with colored triangle and distance output
- add toolbar button to launch measurement mode

## Testing
- `pre-commit run --files ui/measure_tool.py ui/main_menu.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894d049d508832c835c5a79c11a50cf